### PR TITLE
package hexyl to archlinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ wget "https://github.com/sharkdp/hexyl/releases/download/v0.2.0/hexyl_0.2.0_amd6
 sudo dpkg -i hexyl_0.2.0_amd64.deb
 ```
 
-### On Arch Linux, you can be installed [from the AUR](https://aur.archlinux.org/packages/hexyl/):
+### On Arch Linux
+
+You can install `hexyl` from [this AUR package](https://aur.archlinux.org/packages/hexyl/):
 
 ```
 yaourt -S hexyl

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ wget "https://github.com/sharkdp/hexyl/releases/download/v0.2.0/hexyl_0.2.0_amd6
 sudo dpkg -i hexyl_0.2.0_amd64.deb
 ```
 
+### On Arch Linux, you can be installed [from the AUR](https://aur.archlinux.org/packages/hexyl/):
+
+```
+yaourt -S hyperfine
+```
+
+
 ### On other distrubutions
 
 Check out the [release page](https://github.com/sharkdp/hexyl/releases) for binary builds.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ sudo dpkg -i hexyl_0.2.0_amd64.deb
 ### On Arch Linux, you can be installed [from the AUR](https://aur.archlinux.org/packages/hexyl/):
 
 ```
-yaourt -S hyperfine
+yaourt -S hexyl
 ```
 
 


### PR DESCRIPTION
I have already packaged hexyl to [aur](https://aur.archlinux.org/packages/hexyl/) for archlinux