### PR TITLE
Add FreeBSD install instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ yay -S hexyl
 brew install hexyl
 ```
 
+### On FreeBSD
+
+```
+pkg install hexyl
+```
+
 ### On other distributions
 
 Check out the [release page](https://github.com/sharkdp/hexyl/releases) for binary builds.


### PR DESCRIPTION
I've just packaged hexyl for FreeBSD. It should be available in a couple of days from the `latest` package repository.

https://svnweb.freebsd.org/changeset/ports/489825