### PR TITLE
Configure Gitpod and add contributing instructions to README.md

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,3 @@
+tasks:
+  - init: cargo build
+  - command: cargo run -- -n256 /dev/urandom

--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ If you have Rust 1.29 or higher, you can install `hexyl` from source via `cargo`
 cargo install hexyl
 ```
 
+## Contributing
+
+### Online
+
+You can build and run `hexyl` in a browser-based development environment:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/sharkdp/hexyl)
+
+### Locally
+
+If you have Rust 1.29 or higher, you can build and run `hexyl` like so:
+```
+git clone https://github.com/sharkdp/hexyl
+cd hexyl
+cargo build
+cargo run -- -n256 /dev/urandom
+```
+
 ## License
 
 Licensed under either of


### PR DESCRIPTION
Hello, thanks a lot for developing `hexyl`!

I took the liberty of configuring Gitpod (an online development environment) for `hexyl` development, and it seems to work like a charm 🎉: 

<img width="1552" alt="screenshot 2019-01-10 at 17 08 29" src="https://user-images.githubusercontent.com/599268/50982481-96280f80-14fd-11e9-9c29-9d219ad445de.png">

You can give it a try first by clicking here:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jankeromnes/hexyl)

I've also added some contribution tips in `README.md`. Please let me know what you think.