### PR TITLE
Add --color flag to disable ANSI sequences

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,7 @@ name = "hexyl"
 version = "0.3.1"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ version = "0.3.1"
 
 [dependencies]
 ansi_term = "0.11"
+atty = "0.2"
 
 [dependencies.clap]
 version = "2"


### PR DESCRIPTION
When printing the output of hexyl to a file (`hexyl file.exe > file.txt`), the `file.txt` file gets polluted by the ANSI escape sequences. Checking whether the application has been launched from inside the terminal or not, allows you to decide whether or not to use them.

I don't have access to a Windows machine, but [atty](https://crates.rs/crates/atty) claims that it has been tested on Windows.