### PR TITLE
Use `get_matches_safe` instead of `get_matches` for consistent exit point from program

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -258,13 +258,11 @@ fn main() {
     let _ = ansi_term::enable_ansi_support();
 
     let result = run();
-    match result {
-        Err(err) => {
-            // The whitespace is being removed from the right because
-            // clap errors add a newline to the end of the output already
-            eprintln!("Error: {}", format!("{}", err).trim_right());
-            std::process::exit(1);
-        }
-        Ok(()) => {}
+
+    if let Err(err) = result {
+        // The whitespace is being removed from the right because
+        // clap errors add a newline to the end of the output already
+        eprintln!("Error: {}", format!("{}", err).trim_right());
+        std::process::exit(1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,7 +190,7 @@ impl<'a> Printer<'a> {
     }
 }
 
-fn run() -> io::Result<()> {
+fn run() -> Result<(), Box<::std::error::Error>> {
     let app = App::new(crate_name!())
         .setting(AppSettings::ColorAuto)
         .setting(AppSettings::ColoredHelp)
@@ -208,7 +208,7 @@ fn run() -> io::Result<()> {
                 .help("read only N bytes from the input"),
         );
 
-    let matches = app.get_matches();
+    let matches = app.get_matches_safe()?;
 
     let stdin = io::stdin();
 
@@ -260,7 +260,9 @@ fn main() {
     let result = run();
     match result {
         Err(err) => {
-            eprintln!("Error: {}", err);
+            // The whitespace is being removed from the right because
+            // clap errors add a newline to the end of the output already
+            eprintln!("Error: {}", format!("{}", err).trim_right());
             std::process::exit(1);
         }
         Ok(()) => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -260,9 +260,12 @@ fn main() {
     let result = run();
 
     if let Err(err) = result {
-        // The whitespace is being removed from the right because
-        // clap errors add a newline to the end of the output already
-        eprintln!("Error: {}", format!("{}", err).trim_right());
-        std::process::exit(1);
+        if let Some(clap_err) = err.downcast_ref::<clap::Error>() {
+            eprint!("{}", clap_err); // Clap errors already have newlines
+            std::process::exit(1);
+        } else {
+            eprintln!("Error: {}", err);
+            std::process::exit(1);
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,10 +262,9 @@ fn main() {
     if let Err(err) = result {
         if let Some(clap_err) = err.downcast_ref::<clap::Error>() {
             eprint!("{}", clap_err); // Clap errors already have newlines
-            std::process::exit(1);
         } else {
             eprintln!("Error: {}", err);
-            std::process::exit(1);
         }
+        std::process::exit(1);
     }
 }


### PR DESCRIPTION
[`get_matches`](https://docs.rs/clap/2.32.0/clap/struct.App.html#method.get_matches) currently displays an error to the user on failure and calls [`process::exit`](https://doc.rust-lang.org/std/process/fn.exit.html). This means that if some sort of error occurs with CLI parsing, then the end of the `main` function is not reached. While this isn't necessarily a problem here, multiple exit points make the code harder to reason about in general. I've replaced `get_matches` with [`get_matches_safe`](https://docs.rs/clap/2.32.0/clap/struct.App.html#method.get_matches_safe), which instead of exiting the program returns a [`ClapResult`](https://docs.rs/clap/2.32.0/clap/type.Result.html). The error is then propagated upwards with the `?` operator, allowing for a consistent exit point on error from the program.

Possible problems with this:
- Calling `--help` and `--version` will currently _always_ be an error (the user won't see an error, but there will be an exit code of 1). I can however check if the error is of kind `ErrorKind::HelpDisplayed` or `ErrorKind::VersionDisplayed` and in those cases exit with a return code of 0. If you feel this is necessary, I will gladly make the appropriate changes to this PR.

Please let me know your thoughts on this and whether I should make any changes.