### PR TITLE
Write lines into an in-memory buffer before printing to stdout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use clap::{App, AppSettings, Arg};
 use ansi_term::Colour;
 use ansi_term::Colour::Fixed;
 
-const BUFFER_SIZE: usize = 64;
+const BUFFER_SIZE: usize = 256;
 
 const COLOR_NULL: Colour = Fixed(242); // grey
 const COLOR_OFFSET: Colour = Fixed(242); // grey


### PR DESCRIPTION
Running them through an in-memory buffer first produces a 25% speedup (when tested against a 1.3MB file).

Also bump the buffer size to 256 bytes. On my machine this pushes it to a 33% speedup.

```
Benchmark #1: ./hexyl-0.3.1 ./hexyl-0.3.1
  Time (mean ± σ):     277.7 ms ±   1.3 ms    [User: 230.7 ms, System: 45.2 ms]
  Range (min … max):   275.9 ms … 280.8 ms
 
Benchmark #2: target/release/hexyl ./hexyl-0.3.1
  Time (mean ± σ):     184.2 ms ±   1.4 ms    [User: 151.7 ms, System: 30.9 ms]
  Range (min … max):   181.4 ms … 186.0 ms
 
Summary
  'target/release/hexyl ./hexyl-0.3.1' ran
    1.51 ± 0.01 times faster than './hexyl-0.3.1 ./hexyl-0.3.1'
```