### PR TITLE
Change exit code for help and version messages to 0

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -272,6 +272,14 @@ fn main() {
     if let Err(err) = result {
         if let Some(clap_err) = err.downcast_ref::<clap::Error>() {
             eprint!("{}", clap_err); // Clap errors already have newlines
+
+            match clap_err.kind {
+                // The exit code should not indicate an error for --help / --version
+                clap::ErrorKind::HelpDisplayed | clap::ErrorKind::VersionDisplayed => {
+                    std::process::exit(0)
+                }
+                _ => (),
+            }
         } else {
             eprintln!("Error: {}", err);
         }


### PR DESCRIPTION
This is a continuation of #31. Currently, when the user does `hexyl --help` or `hexyl --version`, an exit code of 1 is returned; this PR changes it back to 0.

@sharkdp Please let me know what you think!