### PR TITLE
Use 16 colors instead of 256

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,19 +8,19 @@ use std::io::{self, prelude::*, StdoutLock};
 
 use clap::{App, AppSettings, Arg};
 
-use ansi_term::Colour;
-use ansi_term::Colour::Fixed;
+use ansi_term::Color;
+use ansi_term::Color::Fixed;
 
 use atty::Stream;
 
 const BUFFER_SIZE: usize = 256;
 
-const COLOR_NULL: Colour = Fixed(242); // grey
-const COLOR_OFFSET: Colour = Fixed(242); // grey
-const COLOR_ASCII_PRINTABLE: Colour = Fixed(81); // cyan
-const COLOR_ASCII_WHITESPACE: Colour = Fixed(148); // green
-const COLOR_ASCII_OTHER: Colour = Fixed(197); // magenta
-const COLOR_NONASCII: Colour = Fixed(208); // orange
+const COLOR_NULL: Color = Fixed(242); // grey
+const COLOR_OFFSET: Color = Fixed(242); // grey
+const COLOR_ASCII_PRINTABLE: Color = Color::Cyan;
+const COLOR_ASCII_WHITESPACE: Color = Color::Green;
+const COLOR_ASCII_OTHER: Color = Color::Purple;
+const COLOR_NONASCII: Color = Color::Yellow;
 
 enum ByteCategory {
     Null,
@@ -51,7 +51,7 @@ impl Byte {
         }
     }
 
-    fn color(self) -> &'static Colour {
+    fn color(self) -> &'static Color {
         use ByteCategory::*;
 
         match self.category() {
@@ -238,8 +238,10 @@ fn run() -> Result<(), Box<::std::error::Error>> {
                 .value_name("when")
                 .possible_values(&["always", "auto", "never"])
                 .default_value("always")
-                .help("When to use colors. The auto-mode only displays colors if the output \
-                       goes to an interactive terminal"),
+                .help(
+                    "When to use colors. The auto-mode only displays colors if the output \
+                     goes to an interactive terminal",
+                ),
         );
 
     let matches = app.get_matches_safe()?;


### PR DESCRIPTION
closes #18 
closes #34 

Below is how this looks like for different color schemes. The gray could be a little bit lighter for the light color schemes and a bit darker for the dark color schemes, but there is nothing we can do about that.

molokai
![image](https://user-images.githubusercontent.com/4209276/51102290-ae8a7980-17de-11e9-8c3d-1e738717b61e.png)

snazzy
![image](https://user-images.githubusercontent.com/4209276/51102364-f3aeab80-17de-11e9-84df-b7d4de611186.png)

nord
![image](https://user-images.githubusercontent.com/4209276/51102547-a8e16380-17df-11e9-8c15-e32b60f5678d.png)

solarized dark
![image](https://user-images.githubusercontent.com/4209276/51102318-c661fd80-17de-11e9-8f04-a6e72a7744df.png)

solarized light
![image](https://user-images.githubusercontent.com/4209276/51102328-d4b01980-17de-11e9-84aa-6a74ad1c6b6e.png)

gruv
![image](https://user-images.githubusercontent.com/4209276/51102344-e2659f00-17de-11e9-9be9-02c049c286e6.png)
