### PR TITLE
Add -c short and hide values for --bytes long

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -228,6 +228,7 @@ fn run() -> Result<(), Box<::std::error::Error>> {
         .arg(Arg::with_name("file").help("File to display"))
         .arg(
             Arg::with_name("length")
+                .alias("c")
                 .short("n")
                 .long("length")
                 .takes_value(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -235,9 +235,9 @@ fn run() -> Result<(), Box<::std::error::Error>> {
                 .help("Read only N bytes from the input"),
         )
         .arg(
-            Arg::with_name("c")
+            Arg::with_name("bytes")
                 .short("c")
-                .long("c")
+                .long("bytes")
                 .takes_value(true)
                 .hidden(true),
         )
@@ -263,14 +263,9 @@ fn run() -> Result<(), Box<::std::error::Error>> {
         None => Box::new(stdin.lock()),
     };
 
-    if let Some(length) = matches
-        .value_of("length")
-        .and_then(|n| n.parse::<u64>().ok())
-    {
-        reader = Box::new(reader.take(length));
-    }
+    let length_arg = matches.value_of("length").or(matches.value_of("bytes"));
 
-    if let Some(length) = matches.value_of("c").and_then(|n| n.parse::<u64>().ok()) {
+    if let Some(length) = length_arg.and_then(|n| n.parse::<u64>().ok()) {
         reader = Box::new(reader.take(length));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,12 +228,18 @@ fn run() -> Result<(), Box<::std::error::Error>> {
         .arg(Arg::with_name("file").help("File to display"))
         .arg(
             Arg::with_name("length")
-                .alias("c")
                 .short("n")
                 .long("length")
                 .takes_value(true)
                 .value_name("N")
                 .help("Read only N bytes from the input"),
+        )
+        .arg(
+            Arg::with_name("c")
+                .short("c")
+                .long("c")
+                .takes_value(true)
+                .hidden(true),
         )
         .arg(
             Arg::with_name("color")
@@ -261,6 +267,10 @@ fn run() -> Result<(), Box<::std::error::Error>> {
         .value_of("length")
         .and_then(|n| n.parse::<u64>().ok())
     {
+        reader = Box::new(reader.take(length));
+    }
+
+    if let Some(length) = matches.value_of("c").and_then(|n| n.parse::<u64>().ok()) {
         reader = Box::new(reader.take(length));
     }
 


### PR DESCRIPTION
# c alias for length and -n

References #46

### Usage

```bash
hexyl doc/logo.svg --c 100
```

### Caveats

So this is interesting. There doesn't seem to be a way to pass in multiple shortnames.

You also can't define the same `Arg::with_name("same_name")` twice.

_potentially seeing if clap would be OK with adding or getting a PR for multiple shortnames would be another option as well_

So the closest thing I could get was adding an alias which still means `--` instead of `-`.

***

Now one thing that could be done would be to add a new Arg block but that feels repetitive?

```rust
// support both `--c` as well as `-c`
.arg(
    Arg::with_name("c")
        .short("c")
        .long("c")
        .takes_value(true)
        .value_name("N")
        .help("Read only N bytes from the input"),
)

...

// add new conditional to do the same job as `value_of("length")`
if let Some(count) = matches.value_of("c").and_then(|c| c.parse::<u64>().ok()) {
    reader = Box::new(reader.take(count));
}
```

https://docs.rs/clap/2.20.0/clap/struct.Arg.html#short

### If adding a new `--c` / `-c`

The diff would look like (from current commit in PR)

```diff
--- a/src/main.rs
+++ b/src/main.rs
@@ -228,7 +228,6 @@ fn run() -> Result<(), Box<::std::error::Error>> {
         .arg(Arg::with_name("file").help("File to display"))
         .arg(
             Arg::with_name("length")
-                .alias("c")
                 .short("n")
                 .long("length")
                 .takes_value(true)
@@ -236,6 +235,14 @@ fn run() -> Result<(), Box<::std::error::Error>> {
                 .help("Read only N bytes from the input"),
         )
         .arg(
+            Arg::with_name("c")
+                .short("c")
+                .long("c")
+                .takes_value(true)
+                .value_name("N")
+                .help("Read only N bytes from the input"),
+        )
+        .arg(
             Arg::with_name("color")
                 .long("color")
                 .takes_value(true)
@@ -264,6 +271,10 @@ fn run() -> Result<(), Box<::std::error::Error>> {
         reader = Box::new(reader.take(length));
     }

+    if let Some(count) = matches.value_of("c").and_then(|c| c.parse::<u64>().ok()) {
+        reader = Box::new(reader.take(count));
+    }
+
     let show_color = match matches.value_of("color") {
         Some("never") => false,
         Some("auto") => atty::is(Stream::Stdout),
```