### PR TITLE
unhide --bytes/-c - describe alias to --length/-n

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -239,7 +239,8 @@ fn run() -> Result<(), Box<::std::error::Error>> {
                 .short("c")
                 .long("bytes")
                 .takes_value(true)
-                .hidden(true),
+                .value_name("N")
+                .help("An alias for -n/--length"),
         )
         .arg(
             Arg::with_name("color")


### PR DESCRIPTION
References #46 

As discussed here: https://github.com/sharkdp/hexyl/pull/48#issuecomment-460825915

🚀 


![show_bytes_alias_in_help](https://user-images.githubusercontent.com/9837366/52309067-a1d3ee00-2964-11e9-80f0-af629bbe069d.PNG)

***

![image](https://user-images.githubusercontent.com/9837366/52309602-460a6480-2966-11e9-9b7b-e1d4d81a945e.png)
