### PR TITLE
Fixes issue with header printing before data in some scenarios

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -165,6 +165,7 @@ impl<'a> Printer<'a> {
             0 => {
                 if !self.header_was_printed {
                     self.header();
+                    self.header_was_printed = true;
                 }
                 self.print_textline()?;
             }


### PR DESCRIPTION
Fixes issue #47 where header can be printed before the first row of data in some scenarioes.
Attached is before (separate header) and after fix.
![hexyl_header_fix](https://user-images.githubusercontent.com/8171946/52312324-309e3600-2978-11e9-83fc-0bf4c8384856.png)
