### PR TITLE
Fix squeeze state machine and squeeze indicator coloring

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,8 @@ use clap::{App, AppSettings, Arg};
 use ansi_term::Color;
 use ansi_term::Color::Fixed;
 
-use atty::Stream;
 use crate::squeezer::{SqueezeAction, Squeezer};
+use atty::Stream;
 
 const BUFFER_SIZE: usize = 256;
 
@@ -369,10 +369,15 @@ impl<'a> Printer<'a> {
             SqueezeAction::Print => {
                 self.buffer_line.clear();
                 let style = COLOR_OFFSET.normal();
+                let asterisk = if self.show_color {
+                    format!("{}", style.paint("*"))
+                } else {
+                    String::from("*")
+                };
                 let _ = writeln!(
                     &mut self.buffer_line,
                     "{5}{0}{1:2$}{5}{1:3$}{6}{1:3$}{5}{1:4$}{6}{1:4$}{5}",
-                    style.paint("*"),
+                    asterisk,
                     "",
                     7,
                     25,


### PR DESCRIPTION
 Fixes squeeze state-machine for first/last

Consider equality for first and last character of a line.

If the first or last character of a line is not equal to previous character,
the state machine should be set back to probe as the line should not be
squeezed.

The unit tests has been expanded for testing the use case described in #62.
Further the body of all unit tests has been simplified.

Fixes #62

-----

Consider color when printing squeeze indicator

When color option has been set to never, the squeeze indicator
character asterisk '*' should not be printed in color.

Fixes #63
