### PR TITLE
Speed up hexyl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ ctrlc = "3.1"
 [dependencies.clap]
 version = "2"
 features = ["suggestions", "color", "wrap_help"]
+
+[profile.release]
+lto = true
+codegen-units = 1

--- a/src/squeezer.rs
+++ b/src/squeezer.rs
@@ -86,17 +86,23 @@ impl Squeezer {
         }
     }
 
-    pub fn action(&mut self) -> SqueezeAction {
+    pub fn action(&self) -> SqueezeAction {
+        match self.state {
+            SqueezeState::SqueezeFirstLine => SqueezeAction::Print,
+            SqueezeState::Squeeze => SqueezeAction::Delete,
+            _ => SqueezeAction::Ignore,
+        }
+    }
+
+    pub fn advance(&mut self) {
         match self.state {
             SqueezeState::SqueezeFirstLine => {
                 self.state = SqueezeState::SqueezeActive;
-                SqueezeAction::Print
             }
             SqueezeState::Squeeze => {
                 self.state = SqueezeState::SqueezeActive;
-                SqueezeAction::Delete
             }
-            _ => SqueezeAction::Ignore,
+            _ => {}
         }
     }
 }
@@ -112,6 +118,7 @@ mod tests {
         let mut s = Squeezer::new(true);
         // just initialized
         assert_eq!(s.action(), SqueezeAction::Ignore);
+        s.advance();
 
         let exp = vec![
             SqueezeAction::Ignore, // first line, print as is
@@ -127,6 +134,7 @@ mod tests {
                 idx += 1;
             }
             let action = s.action();
+            s.advance();
             assert_eq!(action, exp[line]);
             line += 1;
         }
@@ -139,6 +147,7 @@ mod tests {
         let mut s = Squeezer::new(true);
         // just initialized
         assert_eq!(s.action(), SqueezeAction::Ignore);
+        s.advance();
 
         let exp = vec![
             SqueezeAction::Ignore, // first line, print as is
@@ -155,6 +164,7 @@ mod tests {
                 idx += 1;
             }
             assert_eq!(s.action(), exp[line]);
+            s.advance();
             line += 1;
         }
     }
@@ -170,6 +180,7 @@ mod tests {
         let mut s = Squeezer::new(true);
         // just initialized
         assert_eq!(s.action(), SqueezeAction::Ignore);
+        s.advance();
 
         let exp = vec![
             SqueezeAction::Ignore, // first line, print as is
@@ -186,6 +197,7 @@ mod tests {
             }
             let action = s.action();
             assert_eq!(action, exp[line]);
+            s.advance();
             line += 1;
         }
     }
@@ -201,6 +213,7 @@ mod tests {
         let mut s = Squeezer::new(true);
         // just initialized
         assert_eq!(s.action(), SqueezeAction::Ignore);
+        s.advance();
 
         let exp = vec![
             SqueezeAction::Ignore, // first line, print as is
@@ -216,6 +229,7 @@ mod tests {
                 idx += 1;
             }
             let action = s.action();
+            s.advance();
             assert_eq!(action, exp[line]);
             line += 1;
         }
@@ -232,6 +246,7 @@ mod tests {
         let mut s = Squeezer::new(true);
         // just initialized
         assert_eq!(s.action(), SqueezeAction::Ignore);
+        s.advance();
 
         let exp = vec![
             SqueezeAction::Ignore, // first line, print as is
@@ -246,6 +261,7 @@ mod tests {
                 idx += 1;
             }
             let action = s.action();
+            s.advance();
             assert_eq!(action, exp[line]);
             line += 1;
         }
@@ -265,6 +281,7 @@ mod tests {
         let mut s = Squeezer::new(true);
         // just initialized
         assert_eq!(s.action(), SqueezeAction::Ignore);
+        s.advance();
 
         let exp = vec![
             SqueezeAction::Ignore, // first line, print as is
@@ -280,6 +297,7 @@ mod tests {
                 idx += 1;
             }
             let action = s.action();
+            s.advance();
             assert_eq!(action, exp[line]);
             line += 1;
         }
@@ -304,6 +322,7 @@ mod tests {
         let mut s = Squeezer::new(true);
         // just initialized
         assert_eq!(s.action(), SqueezeAction::Ignore);
+        s.advance();
 
         let exp = vec![
             SqueezeAction::Ignore,
@@ -328,6 +347,7 @@ mod tests {
                 idx += 1;
             }
             let action = s.action();
+            s.advance();
             assert_eq!(action, exp[line]);
             line += 1;
         }
@@ -346,6 +366,7 @@ mod tests {
         let mut s = Squeezer::new(true);
         // just initialized
         assert_eq!(s.action(), SqueezeAction::Ignore);
+        s.advance();
 
         let exp = vec![
             SqueezeAction::Ignore, // print as is
@@ -362,6 +383,7 @@ mod tests {
                 idx += 1;
             }
             assert_eq!(s.action(), exp[line]);
+            s.advance();
             line += 1;
         }
     }
@@ -378,6 +400,7 @@ mod tests {
         let mut s = Squeezer::new(true);
         // just initialized
         assert_eq!(s.action(), SqueezeAction::Ignore);
+        s.advance();
 
         let exp = vec![
             SqueezeAction::Ignore, // print as is
@@ -393,6 +416,7 @@ mod tests {
                 idx += 1;
             }
             assert_eq!(s.action(), exp[line]);
+            s.advance();
             line += 1;
         }
     }


### PR DESCRIPTION
this PR:

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `hexyl data` | 588.3 ± 3.7 | 585.2 | 596.1 | 36.01 |
| `hexyl --color=never data` | 431.6 ± 7.0 | 425.2 | 447.5 | 26.42 |
| `hexdump -C data` | 16.3 ± 0.6 | 15.7 | 20.2 | 1.00 |
| `xxd data` | 706.3 ± 4.6 | 701.5 | 716.4 | 43.24 |

before:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `hexyl data` | 1.031 ± 0.007 | 1.023 | 1.047 | 62.40 |
| `hexyl --color=never data` | 0.839 ± 0.005 | 0.834 | 0.848 | 50.79 |

benchmark command:
```
dd if=/dev/zero    bs=10M count=1 >  data
dd if=/dev/urandom bs=1k  count=1 >> data

hyperfine --warmup 5 \   
    'hexyl data' \
    'hexyl --color=never data' \
    'hexdump -C data' \
    'xxd data' \
    --export-markdown results.md
```

this means that we now clearly beat `xxd` (in this scenario) and can close #66  :smile: 