### PR TITLE
Option for reading between two offsets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hexyl"
 version = "0.6.0"
 dependencies = [
@@ -72,6 +80,7 @@ dependencies = [
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -135,6 +144,11 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "version_check"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,6 +191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum ctrlc 3.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7dfd2d8b4c82121dfdff120f818e09fc4380b0b7e17a742081a89b94853e87f"
+"checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
@@ -185,6 +200,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
+"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,11 @@ ctrlc = "3.1"
 version = "2"
 features = ["suggestions", "color", "wrap_help"]
 
+[dependencies.error-chain]
+version = "0.12"
+default-features = false
+features = []
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -252,7 +252,7 @@ mod tests {
     #[test]
     fn parse_empty_range() {
         let (offset, bytes_to_read) = parse_range(":").expect("Not allowed to fail test.");
-        assert_eq!(offset, u64::min_value());
+        assert_eq!(offset, 0);
         assert_eq!(bytes_to_read, u64::max_value());
     }
 
@@ -270,11 +270,11 @@ mod tests {
     #[test]
     fn parse_ending_offset() {
         let (offset, bytes_to_read) = parse_range(":0x200").expect("Not allowed to fail test.");
-        assert_eq!(offset, u64::min_value());
+        assert_eq!(offset, 0);
         assert_eq!(bytes_to_read, 512);
 
         let (offset, bytes_to_read) = parse_range(":+512").expect("Not allowed to fail test.");
-        assert_eq!(offset, u64::min_value());
+        assert_eq!(offset, 0);
         assert_eq!(bytes_to_read, 512);
 
         let (offset, bytes_to_read) = parse_range("512:512").expect("Not allowed to fail test.");

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -33,7 +33,6 @@ mod errors {
 
 use crate::errors::*;
 
-
 fn run() -> Result<()> {
     let app = App::new(crate_name!())
         .setting(AppSettings::ColorAuto)
@@ -136,7 +135,9 @@ fn run() -> Result<()> {
         if let Ok((offset, num_bytes)) = parse_range(range) {
             range_offset = offset;
             let mut discard = vec![0u8; offset as usize];
-            reader.read_exact(&mut discard).map_err(|_| format!("Unable to start reading at {}, input too small", offset))?;
+            reader
+                .read_exact(&mut discard)
+                .map_err(|_| format!("Unable to start reading at {}, input too small", offset))?;
             reader = Box::new(reader.take(num_bytes));
         }
     }
@@ -174,7 +175,9 @@ fn run() -> Result<()> {
 
     let mut printer = Printer::new(&mut stdout_lock, show_color, border_style, squeeze);
     printer.display_offset(display_offset as usize);
-    printer.print_all(&mut reader, Some(cancelled)).map_err(|err| format!("{}", err))?;
+    printer
+        .print_all(&mut reader, Some(cancelled))
+        .map_err(|err| format!("{}", err))?;
 
     Ok(())
 }
@@ -198,7 +201,7 @@ fn main() {
                     }
                     _ => (),
                 }
-            },
+            }
             Error(err, _) => eprintln!("Error: {}", err),
         }
         std::process::exit(1);
@@ -216,23 +219,29 @@ fn parse_hex_or_int(n: &str) -> Option<u64> {
 
 fn parse_range(range_raw: &str) -> Result<(u64, u64)> {
     match range_raw.split(':').collect::<Vec<&str>>()[..] {
-      [offset_raw, bytes_to_read_raw] => {
-        let offset = parse_hex_or_int(&offset_raw).unwrap_or_else(u64::min_value);
-        let bytes_to_read = match parse_hex_or_int(bytes_to_read_raw) {
-            Some(num) if bytes_to_read_raw.starts_with('+') => num,
-            Some(num) if offset <= num => num - offset,
-            Some(num) => return Err(format!("cannot start reading at {} and stop reading at {}", offset, num).into()),
-            None if bytes_to_read_raw != "" => return Err("unable to parse range".into()),
-            None => u64::max_value(),
-        };
-        Ok((offset, bytes_to_read))
-      },
-      [offset_raw] => {
-        let offset = parse_hex_or_int(&offset_raw).unwrap_or_else(u64::min_value);
-        let bytes_to_read = u64::max_value();
-        Ok((offset, bytes_to_read))
-      },
-      _ => Err("expected single ':' character".into()),
+        [offset_raw, bytes_to_read_raw] => {
+            let offset = parse_hex_or_int(&offset_raw).unwrap_or_else(u64::min_value);
+            let bytes_to_read = match parse_hex_or_int(bytes_to_read_raw) {
+                Some(num) if bytes_to_read_raw.starts_with('+') => num,
+                Some(num) if offset <= num => num - offset,
+                Some(num) => {
+                    return Err(format!(
+                        "cannot start reading at {} and stop reading at {}",
+                        offset, num
+                    )
+                    .into())
+                }
+                None if bytes_to_read_raw != "" => return Err("unable to parse range".into()),
+                None => u64::max_value(),
+            };
+            Ok((offset, bytes_to_read))
+        }
+        [offset_raw] => {
+            let offset = parse_hex_or_int(&offset_raw).unwrap_or_else(u64::min_value);
+            let bytes_to_read = u64::max_value();
+            Ok((offset, bytes_to_read))
+        }
+        _ => Err("expected single ':' character".into()),
     }
 }
 
@@ -279,10 +288,10 @@ mod tests {
 
     #[test]
     fn parse_bad_input() {
-      let result = parse_range("1024:512");
-      assert!(result.is_err());
+        let result = parse_range("1024:512");
+        assert!(result.is_err());
 
-      let result = parse_range("512:-512");
-      assert!(result.is_err());
+        let result = parse_range("512:-512");
+        assert!(result.is_err());
     }
 }

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -254,6 +254,10 @@ mod tests {
         let (offset, bytes_to_read) = parse_range(":").expect("Not allowed to fail test.");
         assert_eq!(offset, 0);
         assert_eq!(bytes_to_read, u64::max_value());
+
+        let (offset, bytes_to_read) = parse_range("").expect("Not allowed to fail test.");
+        assert_eq!(offset, 0);
+        assert_eq!(bytes_to_read, u64::max_value());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,7 +413,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
         &mut self,
         mut reader: Reader,
         canceller: Option<Cancelled>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), std::io::Error> {
         let mut buffer = [0; BUFFER_SIZE];
         'mainloop: loop {
             let size = reader.read(&mut buffer)?;


### PR DESCRIPTION
I have tried to implement the syntax suggested in the discussion on issue #16.

```
$ hexyl --range 512:1024 # Means "start at 512th byte, read until byte 1024 (512 bytes)"
$ hexyl --range 512:+512 # Means "start at 512th byte, read 512 bytes"

$ hexyl --range +512:    # Means "start at 512th byte".
```

I did not add support for negative offsets simply because I do not see a simple way to implement it for `Stdin`. If required, I suppose it could be implemented with a buffering solution that reads `M - N` bytes into a buffer until it reaches the end of `Stdin` before passing it to a reader.

My solution differs from #43 by not modifying the Printer itself, merely the Reader that it receives. This means that it works just as well for `Stdin` as for a file. A consequence of this is that the bytes are no longer automatically "aligned" in the output, but that just might be what you want in this situation.

```
$ hexyl -r :+0x20 hexyl
┌────────┬─────────────────────────┬─────────────────────────┬────────┬────────┐
│00000000│ 7f 45 4c 46 02 01 01 00 ┊ 00 00 00 00 00 00 00 00 │•ELF•••0┊00000000│
│00000010│ 03 00 3e 00 01 00 00 00 ┊ 30 d1 02 00 00 00 00 00 │•0>0•000┊0×•00000│
└────────┴─────────────────────────┴─────────────────────────┴────────┴────────┘

$ hexyl -r 0x3:+0x20 hexyl
┌────────┬─────────────────────────┬─────────────────────────┬────────┬────────┐
│00000003│ 46 02 01 01 00 00 00 00 ┊ 00 00 00 00 00 03 00 3e │F•••0000┊00000•0>│
│00000013│ 00 01 00 00 00 30 d1 02 ┊ 00 00 00 00 00 40 00 00 │0•0000×•┊00000@00│
└────────┴─────────────────────────┴─────────────────────────┴────────┴────────┘
```

This is my first contribution of Rust code and I welcome suggestions that can help me improve! :)