### PR TITLE
Scarf install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/sharkdp/hexyl.svg?branch=master)](https://travis-ci.org/sharkdp/hexyl)
 [![](https://img.shields.io/crates/l/hexyl.svg?colorB=22ba4c)](https://crates.io/crates/hexyl)
 ![](https://img.shields.io/crates/v/hexyl.svg?colorB=00aa88)
+[![Scarf](https://scarf.sh/package/badge/hexyl)](https://scarf.sh/package/scarf/hexyl)
 
 `hexyl` is a simple hex viewer for the terminal. It uses a colored output to distinguish different categories
 of bytes (NULL bytes, printable ASCII characters, ASCII whitespace characters, other ASCII characters and non-ASCII).
@@ -50,6 +51,14 @@ pkg install hexyl
 
 ```
 nix-env -i hexyl
+```
+
+### Via Scarf
+
+If you'd like to support this project, `hexyl` is available via [Scarf](https://scarf.sh/package/scarf/hexyl):
+
+```
+scarf install hexyl
 ```
 
 ### On other distributions


### PR DESCRIPTION
Hello! This change adds install instructions with the [Scarf](https://scarf.sh) package manager (disclaimer: I'm the author of Scarf).

I saw that hexyl is being supported on Github Sponsors. Scarf could be an additional way to support this project, especially from those using it in a commercial setting. It will collect and provide you with usage statistics as well as offer the ability to collect payments to opt out, so anyone who installs hexyl in this way will be supporting the project in one form or another.

I'd be happy to transfer package ownership and/or co-maintain it, so no extra work required on your part.

I also opened a similar PR on `fd`, so apologies for the noise if you already saw that 😄 