### PR TITLE
Add unit system (closes #44)

### DIFF
--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate clap;
 
-use atty;
-
 use std::fs::File;
 use std::io::{self, prelude::*, SeekFrom};
 

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -163,7 +163,11 @@ fn main() {
 
 fn parse_hex_or_int(n: &str) -> Option<u64> {
     if n.starts_with("0x") {
-        u64::from_str_radix(n.trim_start_matches("0x"), 16).ok()
+        let n = n.trim_start_matches("0x");
+        if n.chars().next() == Some('+') {
+            return None;
+        }
+        u64::from_str_radix(n, 16).ok()
     } else {
         n.parse::<u64>().ok()
     }

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -191,7 +191,7 @@ fn parse_byte_count(n: &str, block_size: u64) -> Option<u64> {
     };
 
     if n.starts_with(HEX_PREFIX) {
-        let n = n.trim_start_matches(HEX_PREFIX);
+        let n = &n[HEX_PREFIX.len()..];
         if n.chars().next() == Some('+') {
             return None;
         }

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -97,7 +97,9 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         reader.seek(SeekFrom::Start(skip))?;
     }
 
-    let length_arg = matches.value_of("length").or(matches.value_of("bytes"));
+    let length_arg = matches
+        .value_of("length")
+        .or_else(|| matches.value_of("bytes"));
 
     let mut reader = if let Some(length) = length_arg.and_then(parse_hex_or_int) {
         Box::new(reader.take(length))
@@ -122,7 +124,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let display_offset = matches
         .value_of("display_offset")
         .and_then(parse_hex_or_int)
-        .unwrap_or(skip_arg.unwrap_or(0));
+        .unwrap_or_else(|| skip_arg.unwrap_or(0));
 
     let stdout = io::stdout();
     let mut stdout_lock = stdout.lock();

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -162,8 +162,10 @@ fn main() {
 }
 
 fn parse_hex_or_int(n: &str) -> Option<u64> {
-    if n.starts_with("0x") {
-        let n = n.trim_start_matches("0x");
+    const HEX_PREFIX: &'static str = "0x";
+
+    if n.starts_with(HEX_PREFIX) {
+        let n = n.trim_start_matches(HEX_PREFIX);
         if n.chars().next() == Some('+') {
             return None;
         }


### PR DESCRIPTION
This PR is conceptually similar to @aswild's commits mentioned [here](https://github.com/sharkdp/hexyl/issues/44#issuecomment-631085679), except we attempt to parse units *at the first non-ASCII digit*, rather than starting from the first ASCII alphabetical. Tests have been shamelessly stolen from those commits.

There are several other housekeeping commits I've added here. If desired, I can split these out into a separate PR.