### PR TITLE
feat(lib): skip forward when relative forward seeks are specified on non-seekable streams

### DIFF
--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -142,7 +142,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let display_offset = matches
         .value_of("display_offset")
         .and_then(|s| parse_byte_count(s, block_size))
-        .unwrap_or_else(|| skip_arg.unwrap_or(0));
+        .or(skip_arg)
+        .unwrap_or(0);
 
     let stdout = io::stdout();
     let mut stdout_lock = stdout.lock();


### PR DESCRIPTION
An example use case: this will allow the binary to have `--seek` Just Work™ for `stdin` (see #95 for this being implemented). This has been separated out since I think this change will be relatively uncontroversial, while the changes in #95 might be more so.

This is technically a breaking change, since the data and behavior of `Input` is exposed publicly. However, it seems unlikely to me that clients actually depended on a failure in the case that's being changed.