### PR TITLE
BREAKING CHANGE(lib): Use `u64` for `Printer::display_offset` and `Squeezer::process`, not `usize`

### DIFF
--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -149,7 +149,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let mut stdout_lock = stdout.lock();
 
     let mut printer = Printer::new(&mut stdout_lock, show_color, border_style, squeeze);
-    printer.display_offset(display_offset as usize);
+    printer.display_offset(display_offset);
     printer.print_all(&mut reader)?;
 
     Ok(())

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -142,7 +142,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let display_offset = matches
         .value_of("display_offset")
         .and_then(|s| parse_byte_count(s, block_size))
-        .unwrap_or_else(|| skip_arg.unwrap_or(0));
+        .or(skip_arg)
+        .unwrap_or(0);
 
     let stdout = io::stdout();
     let mut stdout_lock = stdout.lock();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ impl BorderStyle {
 }
 
 pub struct Printer<'a, Writer: Write> {
-    idx: usize,
+    idx: u64,
     /// The raw bytes used as input for the current line.
     raw_line: Vec<u8>,
     /// The buffered line built with each byte, ready to print to writer.
@@ -154,7 +154,7 @@ pub struct Printer<'a, Writer: Write> {
     byte_hex_table: Vec<String>,
     byte_char_table: Vec<String>,
     squeezer: Squeezer,
-    display_offset: usize,
+    display_offset: u64,
 }
 
 impl<'a, Writer: Write> Printer<'a, Writer> {
@@ -197,7 +197,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
         }
     }
 
-    pub fn display_offset(&mut self, display_offset: usize) -> &mut Self {
+    pub fn display_offset(&mut self, display_offset: u64) -> &mut Self {
         self.display_offset = display_offset;
         self
     }
@@ -247,7 +247,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
         }
 
         let style = COLOR_OFFSET.normal();
-        let byte_index = format!("{:08x}", (self.idx - 1) + self.display_offset);
+        let byte_index = format!("{:08x}", self.idx - 1 + self.display_offset);
         let formatted_string = if self.show_color {
             format!("{}", style.paint(byte_index))
         } else {

--- a/src/squeezer.rs
+++ b/src/squeezer.rs
@@ -32,7 +32,7 @@ pub enum SqueezeAction {
 }
 
 /// line size
-const LSIZE: usize = 16;
+const LSIZE: u64 = 16;
 
 impl Squeezer {
     pub fn new(enabled: bool) -> Squeezer {
@@ -46,7 +46,7 @@ impl Squeezer {
         }
     }
 
-    pub fn process(&mut self, b: u8, i: usize) {
+    pub fn process(&mut self, b: u8, i: u64) {
         use self::SqueezeState::*;
         if self.state == Disabled {
             return;
@@ -111,10 +111,12 @@ impl Squeezer {
 mod tests {
     use super::*;
 
+    const LSIZE_USIZE: usize = LSIZE as usize;
+
     #[test]
     fn three_same_lines() {
         const LINES: usize = 3;
-        let v = vec![0u8; LINES * LSIZE];
+        let v = vec![0u8; LINES * LSIZE_USIZE];
         let mut s = Squeezer::new(true);
         // just initialized
         assert_eq!(s.action(), SqueezeAction::Ignore);
@@ -128,7 +130,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;
@@ -143,7 +145,7 @@ mod tests {
     #[test]
     fn incomplete_while_squeeze() {
         // fourth line only has 12 bytes and should be printed
-        let v = vec![0u8; 3 * LSIZE + 12];
+        let v = vec![0u8; 3 * LSIZE_USIZE + 12];
         let mut s = Squeezer::new(true);
         // just initialized
         assert_eq!(s.action(), SqueezeAction::Ignore);
@@ -158,7 +160,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;
@@ -190,7 +192,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;
@@ -207,7 +209,7 @@ mod tests {
     /// print
     fn one_squeeze_no_delete() {
         const LINES: usize = 3;
-        let mut v = vec![0u8; (LINES - 1) * LSIZE];
+        let mut v = vec![0u8; (LINES - 1) * LSIZE_USIZE];
         v.extend(vec![1u8; 16]);
 
         let mut s = Squeezer::new(true);
@@ -223,7 +225,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;
@@ -239,7 +241,7 @@ mod tests {
     /// First line all eq, 2nd half eq with first line, then change
     fn second_line_different() {
         const LINES: usize = 2;
-        let mut v = vec![0u8; (LINES - 1) * LSIZE];
+        let mut v = vec![0u8; (LINES - 1) * LSIZE_USIZE];
         v.extend(vec![0u8; 8]);
         v.extend(vec![1u8; 8]);
 
@@ -255,7 +257,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;
@@ -291,7 +293,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;
@@ -341,7 +343,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;
@@ -377,7 +379,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;
@@ -410,7 +412,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;


### PR DESCRIPTION
~~Soft dependency on #93.~~

Technically a breaking change for architectures where `size_of::<usize>() > size_of::<u64>()`, but that strikes me as extremely unlikely.

This change is important because most file seek offsets, even on older architectures with word sizes smaller than `u32`, accept a `u64`. In particular, Rust's own `std` acknowledges this. So, we're actually going against prior art in Rust by using a `usize`.