### PR TITLE
Take advantage of skip behavior from #93 for `--seek` for non-`Seek` `Input`s

### DIFF
--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate clap;
 
+use std::convert::TryFrom;
 use std::fs::File;
 use std::io::{self, prelude::*, SeekFrom};
 
@@ -103,15 +104,15 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let block_size = matches
         .value_of("block_size")
-        .and_then(|bs| bs.parse::<u64>().ok())
-        .unwrap_or(512);
+        .and_then(|bs| bs.parse().ok().and_then(PositiveI64::new))
+        .unwrap_or_else(|| PositiveI64::new(512).unwrap());
 
     let skip_arg = matches
         .value_of("skip")
         .and_then(|s| parse_byte_count(s, block_size));
 
-    if let Some(skip) = skip_arg {
-        reader.seek(SeekFrom::Start(skip))?;
+    if let Some(skip) = skip_arg.clone() {
+        reader.seek(SeekFrom::Current(skip.into_inner()))?;
     }
 
     let length_arg = matches
@@ -120,7 +121,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut reader = if let Some(length) = length_arg.and_then(|s| parse_byte_count(s, block_size))
     {
-        Box::new(reader.take(length))
+        Box::new(reader.take(length.into()))
     } else {
         reader.into_inner()
     };
@@ -143,7 +144,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         .value_of("display_offset")
         .and_then(|s| parse_byte_count(s, block_size))
         .or(skip_arg)
-        .unwrap_or(0);
+        .unwrap_or_default()
+        .into();
 
     let stdout = io::stdout();
     let mut stdout_lock = stdout.lock();
@@ -180,23 +182,49 @@ fn main() {
     }
 }
 
-fn parse_byte_count(n: &str, block_size: u64) -> Option<u64> {
+#[derive(Clone, Copy, Debug, Default, Hash, Eq, Ord, PartialEq, PartialOrd)]
+pub struct PositiveI64(i64);
+
+impl PositiveI64 {
+    pub fn new(x: i64) -> Option<Self> {
+        if x.is_negative() {
+            None
+        } else {
+            Some(Self(x))
+        }
+    }
+
+    pub fn into_inner(self) -> i64 {
+        self.0
+    }
+}
+
+impl Into<u64> for PositiveI64 {
+    fn into(self) -> u64 {
+        u64::try_from(self.0)
+            .expect("invariant broken: PositiveI64 should contain a positive i64 value")
+    }
+}
+
+fn parse_byte_count(n: &str, block_size: PositiveI64) -> Option<PositiveI64> {
     const HEX_PREFIX: &'static str = "0x";
 
     let n = {
         let mut chars = n.chars();
         match chars.next()? {
             '+' => chars.as_str(),
+            '-' => return None,
             _ => n,
         }
     };
 
     if n.starts_with(HEX_PREFIX) {
         let n = &n[HEX_PREFIX.len()..];
-        if n.chars().next() == Some('+') {
-            return None;
+        match n.chars().next() {
+            Some('+') | Some('-') => return None,
+            _ => (),
         }
-        return u64::from_str_radix(n, 16).ok();
+        return i64::from_str_radix(n, 16).ok().and_then(PositiveI64::new);
     }
 
     let (n, unit_multiplier) = match n.chars().position(|c| !c.is_ascii_digit()) {
@@ -207,15 +235,15 @@ fn parse_byte_count(n: &str, block_size: u64) -> Option<u64> {
                 n,
                 [
                     ("b", 1),
-                    ("kb", 1000u64.pow(1)),
-                    ("mb", 1000u64.pow(2)),
-                    ("gb", 1000u64.pow(3)),
-                    ("tb", 1000u64.pow(4)),
-                    ("kib", 1024u64.pow(1)),
-                    ("mib", 1024u64.pow(2)),
-                    ("gib", 1024u64.pow(3)),
-                    ("tib", 1024u64.pow(4)),
-                    ("block", block_size),
+                    ("kb", 1000i64.pow(1)),
+                    ("mb", 1000i64.pow(2)),
+                    ("gb", 1000i64.pow(3)),
+                    ("tb", 1000i64.pow(4)),
+                    ("kib", 1024i64.pow(1)),
+                    ("mib", 1024i64.pow(2)),
+                    ("gib", 1024i64.pow(3)),
+                    ("tib", 1024i64.pow(4)),
+                    ("block", block_size.into_inner()),
                 ]
                 .iter()
                 .cloned()
@@ -231,7 +259,10 @@ fn parse_byte_count(n: &str, block_size: u64) -> Option<u64> {
         None => (n, 1),
     };
 
-    n.parse::<u64>().ok()?.checked_mul(unit_multiplier)
+    n.parse::<i64>()
+        .ok()?
+        .checked_mul(unit_multiplier)
+        .and_then(PositiveI64::new)
 }
 
 #[test]
@@ -241,13 +272,19 @@ fn test_parse_byte_count() {
             success!($input, 512, $expected)
         };
         ($input: expr, $block_size: expr, $expected: expr) => {
-            assert_eq!(parse_byte_count($input, $block_size), Some($expected));
+            assert_eq!(
+                parse_byte_count($input, PositiveI64::new($block_size).unwrap()),
+                Some(PositiveI64::new($expected).unwrap())
+            );
         };
     }
 
     macro_rules! error {
         ($input: expr) => {
-            assert_eq!(parse_byte_count($input, 512), None);
+            assert_eq!(
+                parse_byte_count($input, PositiveI64::new(512).unwrap()),
+                None
+            );
         };
     }
 

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -149,7 +149,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let mut stdout_lock = stdout.lock();
 
     let mut printer = Printer::new(&mut stdout_lock, show_color, border_style, squeeze);
-    printer.display_offset(display_offset as usize);
+    printer.display_offset(display_offset);
     printer.print_all(&mut reader)?;
 
     Ok(())

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -142,7 +142,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     let display_offset = matches
         .value_of("display_offset")
         .and_then(|s| parse_byte_count(s, block_size))
-        .unwrap_or_else(|| skip_arg.unwrap_or(0));
+        .or(skip_arg)
+        .unwrap_or(0);
 
     let stdout = io::stdout();
     let mut stdout_lock = stdout.lock();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ impl BorderStyle {
 }
 
 pub struct Printer<'a, Writer: Write> {
-    idx: usize,
+    idx: u64,
     /// The raw bytes used as input for the current line.
     raw_line: Vec<u8>,
     /// The buffered line built with each byte, ready to print to writer.
@@ -154,7 +154,7 @@ pub struct Printer<'a, Writer: Write> {
     byte_hex_table: Vec<String>,
     byte_char_table: Vec<String>,
     squeezer: Squeezer,
-    display_offset: usize,
+    display_offset: u64,
 }
 
 impl<'a, Writer: Write> Printer<'a, Writer> {
@@ -197,7 +197,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
         }
     }
 
-    pub fn display_offset(&mut self, display_offset: usize) -> &mut Self {
+    pub fn display_offset(&mut self, display_offset: u64) -> &mut Self {
         self.display_offset = display_offset;
         self
     }
@@ -247,7 +247,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
         }
 
         let style = COLOR_OFFSET.normal();
-        let byte_index = format!("{:08x}", (self.idx - 1) + self.display_offset);
+        let byte_index = format!("{:08x}", self.idx - 1 + self.display_offset);
         let formatted_string = if self.show_color {
             format!("{}", style.paint(byte_index))
         } else {

--- a/src/squeezer.rs
+++ b/src/squeezer.rs
@@ -32,7 +32,7 @@ pub enum SqueezeAction {
 }
 
 /// line size
-const LSIZE: usize = 16;
+const LSIZE: u64 = 16;
 
 impl Squeezer {
     pub fn new(enabled: bool) -> Squeezer {
@@ -46,7 +46,7 @@ impl Squeezer {
         }
     }
 
-    pub fn process(&mut self, b: u8, i: usize) {
+    pub fn process(&mut self, b: u8, i: u64) {
         use self::SqueezeState::*;
         if self.state == Disabled {
             return;
@@ -111,10 +111,12 @@ impl Squeezer {
 mod tests {
     use super::*;
 
+    const LSIZE_USIZE: usize = LSIZE as usize;
+
     #[test]
     fn three_same_lines() {
         const LINES: usize = 3;
-        let v = vec![0u8; LINES * LSIZE];
+        let v = vec![0u8; LINES * LSIZE_USIZE];
         let mut s = Squeezer::new(true);
         // just initialized
         assert_eq!(s.action(), SqueezeAction::Ignore);
@@ -128,7 +130,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;
@@ -143,7 +145,7 @@ mod tests {
     #[test]
     fn incomplete_while_squeeze() {
         // fourth line only has 12 bytes and should be printed
-        let v = vec![0u8; 3 * LSIZE + 12];
+        let v = vec![0u8; 3 * LSIZE_USIZE + 12];
         let mut s = Squeezer::new(true);
         // just initialized
         assert_eq!(s.action(), SqueezeAction::Ignore);
@@ -158,7 +160,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;
@@ -190,7 +192,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;
@@ -207,7 +209,7 @@ mod tests {
     /// print
     fn one_squeeze_no_delete() {
         const LINES: usize = 3;
-        let mut v = vec![0u8; (LINES - 1) * LSIZE];
+        let mut v = vec![0u8; (LINES - 1) * LSIZE_USIZE];
         v.extend(vec![1u8; 16]);
 
         let mut s = Squeezer::new(true);
@@ -223,7 +225,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;
@@ -239,7 +241,7 @@ mod tests {
     /// First line all eq, 2nd half eq with first line, then change
     fn second_line_different() {
         const LINES: usize = 2;
-        let mut v = vec![0u8; (LINES - 1) * LSIZE];
+        let mut v = vec![0u8; (LINES - 1) * LSIZE_USIZE];
         v.extend(vec![0u8; 8]);
         v.extend(vec![1u8; 8]);
 
@@ -255,7 +257,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;
@@ -291,7 +293,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;
@@ -341,7 +343,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;
@@ -377,7 +379,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;
@@ -410,7 +412,7 @@ mod tests {
 
         let mut line = 0;
         let mut idx = 1;
-        for z in v.chunks(LSIZE) {
+        for z in v.chunks(LSIZE_USIZE) {
             for i in z {
                 s.process(*i, idx);
                 idx += 1;


### PR DESCRIPTION
~~Hard dependency on #93~~, less hard on #94.

Prior to this commit, `Input::seek` would fail under the following conditions:

1. For most reasonable I/O failure conditions, like a file being moved or truncated, or the filesystem being interrupted, or...*voodoo*. /me waves hands in the air
2. When attempting to call `File::seek` on a file backed by a pipe (i.e., a FIFO or socket), as noted by the `ESPIPE` error check.
3. When called on a `Stdin` variant, because `StdinLock` doesn't implement `Seek` -- conceptually similar to case 2.

With the lib commit, 2 and 3 are changed to simulate a `SeekFrom::Current(positive_value)` by throwing away `positive_value` bytes by `std::io::copy`ing into `std::io::sink`. With the commit changing the binary, we use `SeekFrom::Current` (instead of `SeekFrom::Start`), since the "current" offset will always be 0 anyway. Speaking in terms of the command line, doing something like this failed before:

```sh
echo 'asdf' | hexyl --skip 2 # hoping to just print 'df'
# Errors out, because we can't `seek` on `Input::Stdin`
```

...but now it should work as intended.

---

This is technically a breaking change because it halves the upper range of accepted values for byte counts. I thought that fine under the assumption it will be rare for users to ever want to specify something in the upper half of `u64`'s value range, especially considering that this can pave the way for having negative byte offsets (instead of just counts).