### PR TITLE
Make error diagnostics for byte count flags (`--skip`, `--length`, `--display-offset`) awesome

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ dependencies = [
  "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -75,9 +76,35 @@ version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "proc-macro2"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "term_size"
@@ -98,8 +125,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -130,10 +180,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 "checksum hermit-abi 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "91780f809e750b0a89f5544be56617ff6b1227ee485bcb06ebe10cdf89bd3b71"
 "checksum libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)" = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
+"checksum proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
+"checksum quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+"checksum syn 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
 "checksum term_size 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
+"checksum thiserror-impl 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
+"checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +63,7 @@ name = "hexyl"
 version = "0.8.0"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -118,6 +124,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+"checksum anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)" = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 
 [dependencies]
 ansi_term = "0.12"
+anyhow = "1.0.31"
 atty = "0.2"
 libc = "0.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ ansi_term = "0.12"
 anyhow = "1.0.31"
 atty = "0.2"
 libc = "0.2"
+thiserror = "1.0.19"
 
 [dependencies.clap]
 version = "2"

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -34,8 +34,8 @@ fn run() -> Result<(), AnyhowError> {
                 .value_name("N")
                 .help(
                     "Only read N bytes from the input. The N argument can also include a \
-                      unit with a decimal prefix (kB, MB, ..) or binary prefix (kiB, MiB, ..).\n\
-                      Examples: --length=64, --length=4KiB",
+                     unit with a decimal prefix (kB, MB, ..) or binary prefix (kiB, MiB, ..).\n\
+                     Examples: --length=64, --length=4KiB",
                 ),
         )
         .arg(
@@ -54,7 +54,7 @@ fn run() -> Result<(), AnyhowError> {
                 .value_name("N")
                 .help(
                     "Skip the first N bytes of the input. The N argument can also include \
-                      a unit (see `--length` for details)",
+                     a unit (see `--length` for details)",
                 ),
         )
         .arg(
@@ -64,7 +64,7 @@ fn run() -> Result<(), AnyhowError> {
                 .value_name("SIZE")
                 .help(
                     "Sets the size of the `block` unit to SIZE.\n\
-                    Examples: --block-size=1024, --block-size=4kB",
+                     Examples: --block-size=1024, --block-size=4kB",
                 ),
         )
         .arg(
@@ -96,7 +96,10 @@ fn run() -> Result<(), AnyhowError> {
                 .value_name("STYLE")
                 .possible_values(&["unicode", "ascii", "none"])
                 .default_value("unicode")
-                .help("Whether to draw a border with Unicode characters, ASCII characters, or none at all"),
+                .help(
+                    "Whether to draw a border with Unicode characters, ASCII characters, \
+                    or none at all",
+                ),
         )
         .arg(
             Arg::with_name("display_offset")
@@ -104,8 +107,10 @@ fn run() -> Result<(), AnyhowError> {
                 .long("display-offset")
                 .takes_value(true)
                 .value_name("N")
-                .help("Add N bytes to the displayed file position. The N argument can also include \
-                a unit (see `--length` for details)"),
+                .help(
+                    "Add N bytes to the displayed file position. The N argument can also \
+                    include a unit (see `--length` for details)",
+                ),
         );
 
     let matches = app.get_matches_safe()?;

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -112,7 +112,7 @@ fn run() -> Result<(), AnyhowError> {
 
     let stdin = io::stdin();
 
-    let mut reader: Input = match matches.value_of("FILE") {
+    let mut reader = match matches.value_of("FILE") {
         Some(filename) => Input::File(File::open(filename)?),
         None => Input::Stdin(stdin.lock()),
     };

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -9,9 +9,11 @@ use clap::{App, AppSettings, Arg};
 
 use atty::Stream;
 
+use anyhow::{anyhow, Error as AnyhowError};
+
 use hexyl::{BorderStyle, Input, Printer};
 
-fn run() -> Result<(), Box<dyn std::error::Error>> {
+fn run() -> Result<(), AnyhowError> {
     let app = App::new(crate_name!())
         .setting(AppSettings::ColorAuto)
         .setting(AppSettings::ColoredHelp)
@@ -165,7 +167,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut printer = Printer::new(&mut stdout_lock, show_color, border_style, squeeze);
     printer.display_offset(display_offset);
-    printer.print_all(&mut reader)?;
+    printer.print_all(&mut reader).map_err(|e| anyhow!(e))?;
 
     Ok(())
 }
@@ -189,7 +191,7 @@ fn main() {
                 _ => (),
             }
         } else {
-            eprintln!("Error: {}", err);
+            eprintln!("Error: {:?}", err);
         }
         std::process::exit(1);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -408,7 +408,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
     pub fn print_all<Reader: Read>(
         &mut self,
         mut reader: Reader,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let mut buffer = [0; BUFFER_SIZE];
         'mainloop: loop {
             let size = reader.read(&mut buffer)?;


### PR DESCRIPTION
This PR adds `anyhow` to the codebase, using it as the reporting layer for contextually layered error diagnostics, and then applying those capabilities to `parse_byte_offset`. Below are inlined the contents of the commits, since I believe they'll be important for discussion of the design of work here and in the future.

---

This adds an error type called `ByteCountParseError` with a vanilla `std::error::Error` implementation. The code could be significantly compressed with a dependency like `thiserror`.

I opted to implement a separate error type for `parse_byte_count` rather than using `anyhow`'s small ecosystem of error types there (though they are used in `<binary>::run`) because it allows pairing diagnostic results with tests, incl. those already written. This can be helpful in preventing regressions in error diagnostics.

---

Using `anyhow` with `{:?}` is deliberate, and significantly changes the structure of potential output of top-level errors.  Before, errors that have a `source` were printed on a single line, with the `source` omitted. Now, an error with a `source` will be printed like:

```
Error: <`Display` impl of error>

Caused by:
    <`Display` impl of `source` error>
```

If there are multiple `source` errors in a chain, then it will be of the form:

```
Error: <`Display` impl of error>

Caused by:
    0: <`Display` impl of first `source` error>
    1: <`Display` impl of `source` of `source` error>
    # etc.
```

Now, in practice this never happened before, since the only error type that ever could return from `<binary>::run` was `std::io::Error`, which has no `source`. However, `source`s can start being added if, say, future work involved using `anyhow::Context::context` or custom errors that implement `std::Error::source` are added to the codebase. I believe this is a good choice for error reporting going forward, but I definitely want to foster discussion and acceptance for it in the open first!