### PR TITLE
add webi install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ of bytes (NULL bytes, printable ASCII characters, ASCII whitespace characters, o
 
 ## Installation
 
+### On Linux
+
+```bash
+curl -fsS https://webinstall.dev/hexyl | bash
+```
+
 ### On Ubuntu
 
 *... and other Debian-based Linux distributions.*
@@ -61,6 +67,12 @@ xbps-install hexyl
 
 ```
 brew install hexyl
+```
+
+or
+
+```bash
+curl -fsS https://webinstall.dev/hexyl | bash
 ```
 
 ### On FreeBSD


### PR DESCRIPTION
So it looks like you are the author of at least three tools that I love. I see @ErichDonGubler is a contributor here is well. Yay!

I've added `hexyl`, `bat`, and `fd` to https://webinstall.dev, all based on the same installer template - except no Windows 10 for `hexyl` :'(

In short, `webi`
- pulls your official builds from the Github Release API
    - (selecting a build that it can unpack with whatever tools are available no the system in question - tar, zip, etc
- places it in `~/.local/opt/<whatever>-<version>`
- creates a symlink to `~/.local/bin/<whatever>`
- updates PATH in `~/.config/envman/PATH.env`

No sudo. No package manager. No nonsense.

- Installer source at https://github.com/webinstall/packages/blob/master/hexyl/