### PR TITLE
Add installation instructions for Guix

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,14 @@ apt install hexyl
 nix-env -i hexyl
 ```
 
+### Via Guix
+
+```
+guix package -i hexyl
+```
+
+Or add the `hexyl` package in the list of packages to be installed in your system configuration (e.g., `/etc/config.scm`).
+
 ### On other distributions
 
 Check out the [release page](https://github.com/sharkdp/hexyl/releases) for binary builds.


### PR DESCRIPTION
I've added Hexyl to the list of packages for Guix (https://guix.gnu.org/en/packages/hexyl-0.8.0/) so I thought to add it here to show GNU has a similar NixOS-inspired system.