### PR TITLE
Fix #131

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Argument `--length` silently takes precedence over `--bytes`, see #105
 - Print warning on empty content, see #107 and #108
 - Disallow block sizes of zero, see #110
+- Fix newline appearing in `--version` output, see #131 and #133 (@scimas)
 
 ## Other
 

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -235,13 +235,18 @@ fn main() {
 
     if let Err(err) = result {
         if let Some(clap_err) = err.downcast_ref::<clap::Error>() {
-            eprint!("{}", clap_err); // Clap errors already have newlines
-
             match clap_err.kind {
                 // The exit code should not indicate an error for --help / --version
-                clap::ErrorKind::HelpDisplayed | clap::ErrorKind::VersionDisplayed => {
+                clap::ErrorKind::HelpDisplayed => {
+                    eprint!("{}", clap_err); // Clap errors already have newlines
                     std::process::exit(0)
-                }
+                },
+                clap::ErrorKind::VersionDisplayed => {
+                    // Version output in clap 2.33.1 (dep as of now) doesn't have a newline
+                    // and the fix is not included even in the latest stable release
+                    println!("");
+                    std::process::exit(0)
+                },
                 _ => (),
             }
         } else {


### PR DESCRIPTION
I noticed that the `eprint` in `main` itself is taking care of the `--help` output, but the `--version` output is coming without the `eprint`. So I have done two changes:

-Don't print the error for version output, instead add a newline print.
-Move the eprint for help only.