### PR TITLE
README: Add `scoop` instruction (on Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Check out the [release page](https://github.com/sharkdp/hexyl/releases) for bina
 ### On Windows
 
 Check out the [release page](https://github.com/sharkdp/hexyl/releases) for binary builds.
-Alternatively, install from source via `cargo` (see below).
+Alternatively, install from source via `cargo`, `snap` or `scoop` (see below).
 Make sure that you use a terminal that supports ANSI escape sequences (like ConHost v2 since Windows 10 1703
 or Windows Terminal since Windows 10 1903).
 
@@ -134,8 +134,14 @@ cargo install hexyl
 ```
 sudo snap install hexyl
 ```
-
 [Get it from the Snap Store](https://snapcraft.io/hexyl)
+
+
+### Via [Scoop](https://scoop.sh)
+```
+scoop install hexyl
+```
+
 
 ## License
 


### PR DESCRIPTION
**hexyl** has been added to the official bucket of [Scoop](https://scoop.sh)
see: https://github.com/ScoopInstaller/Main/pull/2684

If there is any problem, please tell me. Thank you.