### PR TITLE
Adds --columns for Print using custom width #13

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1,7 +1,7 @@
 name: CICD
 
 env:
-  MIN_SUPPORTED_RUST_VERSION: "1.56.0"
+  MIN_SUPPORTED_RUST_VERSION: "1.56.1"
   CICD_INTERMEDIATES_DIR: "_cicd-intermediates"
 
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Features
 
+- Added variable panels through the `--panels` and `--terminal-width` flags, see [#13](https://github.com/sharkdp/hexyl/issues/13) and [#164](https://github.com/sharkdp/hexyl/pull/164) (@sharifhsn)
 
 ## Bugfixes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,27 +75,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "3.1.18"
+name = "cc"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
+name = "clap"
+version = "3.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d646c7ade5eb07c4aa20e907a922750df0c448892513714fd3e4acbc7130829f"
 dependencies = [
  "atty",
  "bitflags",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim",
  "termcolor",
- "terminal_size",
+ "terminal_size 0.1.17",
  "textwrap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -139,6 +145,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +201,7 @@ dependencies = [
  "const_format",
  "libc",
  "predicates",
+ "terminal_size 0.2.1",
  "thiserror",
 ]
 
@@ -186,6 +214,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "io-lifetimes"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24c3f4eff5495aee4c0399d7b6a0dc2b6e81be84242ffbfcf253ebacccc1d0cb"
 
 [[package]]
 name = "itertools"
@@ -209,6 +243,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +268,12 @@ checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "os_str_bytes"
@@ -307,6 +353,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
 
 [[package]]
+name = "rustix"
+version = "0.35.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51cc38aa10f6bbb377ed28197aa052aa4e2b762c22be9d3153d01822587e787"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +403,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "termtree"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,7 +424,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 dependencies = [
- "terminal_size",
+ "terminal_size 0.1.17",
 ]
 
 [[package]]
@@ -428,3 +498,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ atty = "0.2"
 const_format = "0.2"
 libc = "0.2"
 thiserror = "1.0"
+terminal_size = "0.2"
 
 [dependencies.clap]
 version = "3"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -16,6 +16,7 @@ fn main() {
     let show_position_panel = true;
     let use_squeezing = false;
     let border_style = BorderStyle::Unicode;
+    let columns = 2;
 
     let mut printer = Printer::new(
         &mut handle,
@@ -24,6 +25,7 @@ fn main() {
         show_position_panel,
         border_style,
         use_squeezing,
+        columns,
     );
     printer.print_all(&input[..]).unwrap();
 }

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -160,7 +160,8 @@ fn run() -> Result<(), AnyhowError> {
                 .value_name("N")
                 .help(
                     "Sets the number of hex data columns to be displayed. \
-                    Cannot be used with other width-setting options.",
+                    `--columns=auto` will display the maximum number of hex data columns \
+                    based on the current terminal width",
                 ),
         )
         .arg(
@@ -176,16 +177,6 @@ fn run() -> Result<(), AnyhowError> {
                     will use the greatest number of hex data columns that can fit in the requested \
                     width but still leave some space to the right.\nCannot be used with other \
                     width-setting options.",
-                ),
-        )
-        .arg(
-            Arg::new("auto_width")
-                .short('a')
-                .long("auto-width")
-                .conflicts_with_all(&["columns", "terminal_width"])
-                .help(
-                    "Sets the number of hex data columns to be adjusted according to the \
-                    detected terminal width.\nCannot be used with other width-setting options.",
                 ),
         );
 
@@ -305,7 +296,19 @@ fn run() -> Result<(), AnyhowError> {
         .transpose()?
         .unwrap_or(0);
 
-    let columns = if let Some(columns) = matches
+    let max_columns_fn = |terminal_width: u16| {
+        let offset = if show_position_panel { 10 } else { 1 };
+        let col_width = if show_char_panel { 35 } else { 26 };
+        if (terminal_width - offset) / col_width < 1 {
+            1
+        } else {
+            (terminal_width - offset) / col_width
+        }
+    };
+
+    let columns = if matches.value_of("columns") == Some("auto") {
+        max_columns_fn(terminal_size().ok_or_else(|| anyhow!("not a TTY"))?.0 .0)
+    } else if let Some(columns) = matches
         .value_of("columns")
         .map(|s| {
             s.parse::<NonZeroU16>().map(u16::from).context(anyhow!(
@@ -316,8 +319,7 @@ fn run() -> Result<(), AnyhowError> {
         .transpose()?
     {
         columns
-    } else {
-        let terminal_width = if let Some(terminal_width) = matches
+    } else if let Some(terminal_width) = matches
             .value_of("terminal_width")
             .map(|s| {
                 s.parse::<NonZeroU16>().map(u16::from).context(anyhow!(
@@ -327,24 +329,9 @@ fn run() -> Result<(), AnyhowError> {
             })
             .transpose()?
         {
-            Some(terminal_width)
-        } else if matches.is_present("auto_width") {
-            Some(terminal_size().ok_or_else(|| anyhow!("not a TTY"))?.0 .0)
-        } else {
-            None
-        };
-
-        if let Some(terminal_width) = terminal_width {
-            let offset = if show_position_panel { 10 } else { 1 };
-            let col_width = if show_char_panel { 35 } else { 26 };
-            if (terminal_width - offset) / col_width < 1 {
-                1
-            } else {
-                (terminal_width - offset) / col_width
-            }
+        max_columns_fn(terminal_width)
         } else {
             2
-        }
     };
 
     let stdout = io::stdout();

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -154,7 +154,7 @@ fn run() -> Result<(), AnyhowError> {
         )
         .arg(
             Arg::new("panels")
-                .short('p')
+                .short('w')
                 .long("panels")
                 .takes_value(true)
                 .value_name("N")

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -323,7 +323,7 @@ fn run() -> Result<(), AnyhowError> {
             .value_of("terminal_width")
             .map(|s| {
                 s.parse::<NonZeroU16>().map(u16::from).context(anyhow!(
-                    "failed to parse `--columns` arg {:?} as unsigned nonzero integer",
+                "failed to parse `--terminal-width` arg {:?} as unsigned nonzero integer",
                     s
                 ))
             })

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -329,7 +329,7 @@ fn run() -> Result<(), AnyhowError> {
         {
             Some(terminal_width)
         } else if matches.is_present("auto_width") {
-            Some(terminal_size().expect("not a tty").0 .0)
+            Some(terminal_size().ok_or_else(|| anyhow!("not a TTY"))?.0 .0)
         } else {
             None
         };

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -153,14 +153,14 @@ fn run() -> Result<(), AnyhowError> {
                 ),
         )
         .arg(
-            Arg::new("columns")
-                .short('w')
-                .long("columns")
+            Arg::new("panels")
+                .short('p')
+                .long("panels")
                 .takes_value(true)
                 .value_name("N")
                 .help(
-                    "Sets the number of hex data columns to be displayed. \
-                    `--columns=auto` will display the maximum number of hex data columns \
+                    "Sets the number of hex data panels to be displayed. \
+                    `--panels=auto` will display the maximum number of hex data panels \
                     based on the current terminal width",
                 ),
         )
@@ -170,11 +170,11 @@ fn run() -> Result<(), AnyhowError> {
                 .long("terminal-width")
                 .takes_value(true)
                 .value_name("N")
-                .conflicts_with("columns")
+                .conflicts_with("panels")
                 .help(
                     "Sets the number of terminal columns to be displayed.\nSince the terminal \
                     width may not be an evenly divisible by the width per hex data column, this \
-                    will use the greatest number of hex data columns that can fit in the requested \
+                    will use the greatest number of hex data panels that can fit in the requested \
                     width but still leave some space to the right.\nCannot be used with other \
                     width-setting options.",
                 ),
@@ -296,7 +296,7 @@ fn run() -> Result<(), AnyhowError> {
         .transpose()?
         .unwrap_or(0);
 
-    let max_columns_fn = |terminal_width: u16| {
+    let max_panels_fn = |terminal_width: u16| {
         let offset = if show_position_panel { 10 } else { 1 };
         let col_width = if show_char_panel { 35 } else { 26 };
         if (terminal_width - offset) / col_width < 1 {
@@ -306,32 +306,32 @@ fn run() -> Result<(), AnyhowError> {
         }
     };
 
-    let columns = if matches.value_of("columns") == Some("auto") {
-        max_columns_fn(terminal_size().ok_or_else(|| anyhow!("not a TTY"))?.0 .0)
-    } else if let Some(columns) = matches
-        .value_of("columns")
+    let panels = if matches.value_of("panels") == Some("auto") {
+        max_panels_fn(terminal_size().ok_or_else(|| anyhow!("not a TTY"))?.0 .0)
+    } else if let Some(panels) = matches
+        .value_of("panels")
         .map(|s| {
             s.parse::<NonZeroU16>().map(u16::from).context(anyhow!(
-                "failed to parse `--columns` arg {:?} as unsigned nonzero integer",
+                "failed to parse `--panels` arg {:?} as unsigned nonzero integer",
                 s
             ))
         })
         .transpose()?
     {
-        columns
+        panels
     } else if let Some(terminal_width) = matches
-            .value_of("terminal_width")
-            .map(|s| {
-                s.parse::<NonZeroU16>().map(u16::from).context(anyhow!(
+        .value_of("terminal_width")
+        .map(|s| {
+            s.parse::<NonZeroU16>().map(u16::from).context(anyhow!(
                 "failed to parse `--terminal-width` arg {:?} as unsigned nonzero integer",
-                    s
-                ))
-            })
-            .transpose()?
-        {
-        max_columns_fn(terminal_width)
-        } else {
-            2
+                s
+            ))
+        })
+        .transpose()?
+    {
+        max_panels_fn(terminal_width)
+    } else {
+        2
     };
 
     let stdout = io::stdout();
@@ -344,7 +344,7 @@ fn run() -> Result<(), AnyhowError> {
         show_position_panel,
         border_style,
         squeeze,
-        columns,
+        panels,
     );
     printer.display_offset(skip_offset + display_offset);
     printer.print_all(&mut reader).map_err(|e| anyhow!(e))?;

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -154,7 +154,6 @@ fn run() -> Result<(), AnyhowError> {
         )
         .arg(
             Arg::new("panels")
-                .short('w')
                 .long("panels")
                 .takes_value(true)
                 .value_name("N")
@@ -166,7 +165,6 @@ fn run() -> Result<(), AnyhowError> {
         )
         .arg(
             Arg::new("terminal_width")
-                .short('t')
                 .long("terminal-width")
                 .takes_value(true)
                 .value_name("N")

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -4,7 +4,7 @@ extern crate clap;
 use std::convert::TryFrom;
 use std::fs::File;
 use std::io::{self, prelude::*, SeekFrom};
-use std::num::{NonZeroI64, NonZeroU16, NonZeroU8};
+use std::num::{NonZeroI64, NonZeroU16};
 
 use clap::{crate_name, crate_version, AppSettings, Arg, ColorChoice, Command};
 
@@ -308,7 +308,7 @@ fn run() -> Result<(), AnyhowError> {
     let columns = if let Some(columns) = matches
         .value_of("columns")
         .map(|s| {
-            s.parse::<NonZeroU8>().map(u8::from).context(anyhow!(
+            s.parse::<NonZeroU16>().map(u16::from).context(anyhow!(
                 "failed to parse `--columns` arg {:?} as unsigned nonzero integer",
                 s
             ))
@@ -340,9 +340,7 @@ fn run() -> Result<(), AnyhowError> {
             if (terminal_width - offset) / col_width < 1 {
                 1
             } else {
-                ((terminal_width - offset) / col_width)
-                    .try_into()
-                    .expect("there is a maximum of 255 columns")
+                (terminal_width - offset) / col_width
             }
         } else {
             2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,11 +311,16 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
         if len < usize::from(8 * self.columns) {
             let _ = write!(&mut self.buffer_line, "{0:1$}", "", 8 - len % 8);
             for _ in 0..(usize::from(8 * self.columns) - (len + (8 - len % 8))) / 8 {
-                let _ = write!(&mut self.buffer_line, "{2}{0:1$}", "", 8, self.border_style.inner_sep());
+                let _ = write!(
+                    &mut self.buffer_line,
+                    "{2}{0:1$}",
+                    "",
+                    8,
+                    self.border_style.inner_sep()
+                );
             }
         }
         let _ = writeln!(&mut self.buffer_line, "{}", self.border_style.outer_sep());
-
     }
 
     pub fn print_byte(&mut self, b: u8) -> io::Result<()> {
@@ -348,11 +353,29 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
                 self.print_position_panel();
                 write!(&mut self.buffer_line, "{0:1$}", "", 24)?;
                 for _ in 0..self.columns - 1 {
-                    write!(&mut self.buffer_line, "{2}{0:1$}", "", 25, self.border_style.inner_sep())?;
+                    write!(
+                        &mut self.buffer_line,
+                        "{2}{0:1$}",
+                        "",
+                        25,
+                        self.border_style.inner_sep()
+                    )?;
                 }
-                write!(&mut self.buffer_line, "{2}{0:1$}", "", 8, self.border_style.outer_sep())?;
+                write!(
+                    &mut self.buffer_line,
+                    "{2}{0:1$}",
+                    "",
+                    8,
+                    self.border_style.outer_sep()
+                )?;
                 for _ in 0..self.columns - 1 {
-                    write!(&mut self.buffer_line, "{2}{0:1$}", "", 8, self.border_style.inner_sep())?;
+                    write!(
+                        &mut self.buffer_line,
+                        "{2}{0:1$}",
+                        "",
+                        8,
+                        self.border_style.inner_sep()
+                    )?;
                 }
                 writeln!(&mut self.buffer_line, "{}", self.border_style.outer_sep())?;
                 self.writer.write_all(&self.buffer_line)?;
@@ -368,7 +391,13 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
                 write!(&mut self.buffer_line, "{0:1$}", "", 3 * (8 - len % 8))?;
                 // dbg!(usize::from(8 * self.columns) - (len + (8 - len % 8)));
                 for _ in 0..(usize::from(8 * self.columns) - (len + (8 - len % 8))) / 8 {
-                    write!(&mut self.buffer_line, "{2}{0:1$}", "", 1 + 3 * 8, self.border_style.inner_sep())?;
+                    write!(
+                        &mut self.buffer_line,
+                        "{2}{0:1$}",
+                        "",
+                        1 + 3 * 8,
+                        self.border_style.inner_sep()
+                    )?;
                 }
             }
             write!(&mut self.buffer_line, "{}", self.border_style.outer_sep())?;
@@ -385,7 +414,14 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
                     String::from("*")
                 };
 
-                write!(&mut self.buffer_line, "{3}{0}{1:2$}{3}", asterisk, "", 7, self.border_style.outer_sep())?;
+                write!(
+                    &mut self.buffer_line,
+                    "{3}{0}{1:2$}{3}",
+                    asterisk,
+                    "",
+                    7,
+                    self.border_style.outer_sep()
+                )?;
 
                 for i in 0..self.columns {
                     write!(&mut self.buffer_line, "{0:1$}", "", 25)?;
@@ -480,7 +516,15 @@ mod tests {
 
     fn assert_print_all_output<Reader: Read>(input: Reader, expected_string: String) {
         let mut output = vec![];
-        let mut printer = Printer::new(&mut output, false, true, true, BorderStyle::Unicode, true, 2);
+        let mut printer = Printer::new(
+            &mut output,
+            false,
+            true,
+            true,
+            BorderStyle::Unicode,
+            true,
+            2,
+        );
 
         printer.print_all(input).unwrap();
 
@@ -524,8 +568,15 @@ mod tests {
         .to_owned();
 
         let mut output = vec![];
-        let mut printer: Printer<Vec<u8>> =
-            Printer::new(&mut output, false, true, true, BorderStyle::Unicode, true, 2);
+        let mut printer: Printer<Vec<u8>> = Printer::new(
+            &mut output,
+            false,
+            true,
+            true,
+            BorderStyle::Unicode,
+            true,
+            2,
+        );
         printer.display_offset(0xdeadbeef);
 
         printer.print_all(input).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,7 @@ pub struct Printer<'a, Writer: Write> {
     squeezer: Squeezer,
     display_offset: u64,
     /// The number of panels to draw.
-    columns: u8,
+    columns: u16,
 }
 
 impl<'a, Writer: Write> Printer<'a, Writer> {
@@ -166,7 +166,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
         show_position_panel: bool,
         border_style: BorderStyle,
         use_squeeze: bool,
-        columns: u8,
+        columns: u16,
     ) -> Printer<'a, Writer> {
         Printer {
             idx: 1,
@@ -389,7 +389,6 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
         if squeeze_action != SqueezeAction::Delete {
             if len < usize::from(8 * self.columns) {
                 write!(&mut self.buffer_line, "{0:1$}", "", 3 * (8 - len % 8))?;
-                // dbg!(usize::from(8 * self.columns) - (len + (8 - len % 8)));
                 for _ in 0..(usize::from(8 * self.columns) - (len + (8 - len % 8))) / 8 {
                     write!(
                         &mut self.buffer_line,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -584,4 +584,34 @@ mod tests {
         let actual_string: &str = str::from_utf8(&output).unwrap();
         assert_eq!(actual_string, expected_string)
     }
+
+    #[test]
+    fn multiple_columns() {
+        let input = io::Cursor::new(b"supercalifragilisticexpialidocioussupercalifragilisticexpialidocioussupercalifragilisticexpialidocious");
+        let expected_string = "\
+┌────────┬─────────────────────────┬─────────────────────────┬─────────────────────────┬─────────────────────────┬────────┬────────┬────────┬────────┐
+│00000000│ 73 75 70 65 72 63 61 6c ┊ 69 66 72 61 67 69 6c 69 ┊ 73 74 69 63 65 78 70 69 ┊ 61 6c 69 64 6f 63 69 6f │supercal┊ifragili┊sticexpi┊alidocio│
+│00000020│ 75 73 73 75 70 65 72 63 ┊ 61 6c 69 66 72 61 67 69 ┊ 6c 69 73 74 69 63 65 78 ┊ 70 69 61 6c 69 64 6f 63 │ussuperc┊alifragi┊listicex┊pialidoc│
+│00000040│ 69 6f 75 73 73 75 70 65 ┊ 72 63 61 6c 69 66 72 61 ┊ 67 69 6c 69 73 74 69 63 ┊ 65 78 70 69 61 6c 69 64 │ioussupe┊rcalifra┊gilistic┊expialid│
+│00000060│ 6f 63 69 6f 75 73       ┊                         ┊                         ┊                         │ocious  ┊        ┊        ┊        │
+└────────┴─────────────────────────┴─────────────────────────┴─────────────────────────┴─────────────────────────┴────────┴────────┴────────┴────────┘
+"
+        .to_owned();
+
+        let mut output = vec![];
+        let mut printer: Printer<Vec<u8>> = Printer::new(
+            &mut output,
+            false,
+            true,
+            true,
+            BorderStyle::Unicode,
+            true,
+            4,
+        );
+
+        printer.print_all(input).unwrap();
+
+        let actual_string: &str = str::from_utf8(&output).unwrap();
+        assert_eq!(actual_string, expected_string)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,7 +301,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
                 self.byte_char_panel[b as usize]
             );
 
-            if idx % 8 == 0 && idx % (u64::from(self.columns * 8)) != 0 {
+            if idx % 8 == 0 && idx % (u64::from(self.columns) * 8) != 0 {
                 let _ = write!(&mut self.buffer_line, "{}", self.border_style.inner_sep());
             }
 
@@ -324,7 +324,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
     }
 
     pub fn print_byte(&mut self, b: u8) -> io::Result<()> {
-        if self.idx % u64::from(self.columns * 8) == 1 {
+        if self.idx % (u64::from(self.columns) * 8) == 1 {
             self.print_header();
             self.print_position_panel();
         }
@@ -334,7 +334,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
 
         self.squeezer.process(b, self.idx);
 
-        if self.idx % u64::from(self.columns * 8) == 0 {
+        if self.idx % (u64::from(self.columns) * 8) == 0 {
             self.print_textline()?;
         } else if self.idx % 8 == 0 {
             let _ = write!(&mut self.buffer_line, "{} ", self.border_style.inner_sep());

--- a/src/squeezer.rs
+++ b/src/squeezer.rs
@@ -111,7 +111,7 @@ mod tests {
     use super::*;
 
     const LSIZE: u64 = 16;
-    const LSIZE_USIZE: usize = 16;
+    const LSIZE_USIZE: usize = LSIZE as usize;
 
     #[test]
     fn three_same_lines() {


### PR DESCRIPTION
This pull request fixes #13 partially by adding the `--columns` option to manually set the number of columns. The default is 2 as with previous behavior.

Some notes:
- the short option is `-w` not `-c` as that option is already reserved for `--bytes`
- it passes `cargo test`
- I could have added the option to automatically set columns to terminal width, but that would require adding another dependency