### PR TITLE
Implement builder pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ## Features
 
+- Breaking change (library): `Printer::new` is deprecated as a part of the public API. Alternatively, you can now construct a `Printer` using the `PrinterBuilder` builder API, see [#168](https://github.com/sharkdp/hexyl/pull/168). (@sharifhsn)
+
 - Added variable panels through the `--panels` and `--terminal-width` flags, see [#13](https://github.com/sharkdp/hexyl/issues/13) and [#164](https://github.com/sharkdp/hexyl/pull/164) (@sharifhsn)
 
 ## Bugfixes

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use hexyl::{BorderStyle, Printer};
+use hexyl::{BorderStyle, PrinterBuilder};
 
 fn main() {
     let input = vec![
@@ -16,16 +16,15 @@ fn main() {
     let show_position_panel = true;
     let use_squeezing = false;
     let border_style = BorderStyle::Unicode;
-    let columns = 2;
+    let panels = 2;
 
-    let mut printer = Printer::new(
-        &mut handle,
-        show_color,
-        show_char_panel,
-        show_position_panel,
-        border_style,
-        use_squeezing,
-        columns,
-    );
+    let mut printer = PrinterBuilder::new(&mut handle)
+        .show_color(show_color)
+        .show_char_panel(show_char_panel)
+        .show_position_panel(show_position_panel)
+        .with_border_style(border_style)
+        .with_squeeze(use_squeezing)
+        .with_panels(panels)
+        .build();
     printer.print_all(&input[..]).unwrap();
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -16,7 +16,7 @@ fn main() {
         .show_char_panel(true)
         .show_position_panel(true)
         .with_border_style(BorderStyle::Unicode)
-        .with_squeeze(false)
+        .enable_squeezing(false)
         .with_panels(2)
         .build();
     printer.print_all(&input[..]).unwrap();

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -11,20 +11,13 @@ fn main() {
     let stdout = io::stdout();
     let mut handle = stdout.lock();
 
-    let show_color = true;
-    let show_char_panel = true;
-    let show_position_panel = true;
-    let use_squeezing = false;
-    let border_style = BorderStyle::Unicode;
-    let panels = 2;
-
     let mut printer = PrinterBuilder::new(&mut handle)
-        .show_color(show_color)
-        .show_char_panel(show_char_panel)
-        .show_position_panel(show_position_panel)
-        .with_border_style(border_style)
-        .with_squeeze(use_squeezing)
-        .with_panels(panels)
+        .show_color(true)
+        .show_char_panel(true)
+        .show_position_panel(true)
+        .with_border_style(BorderStyle::Unicode)
+        .with_squeeze(false)
+        .with_panels(2)
         .build();
     printer.print_all(&input[..]).unwrap();
 }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -17,7 +17,7 @@ fn main() {
         .show_position_panel(true)
         .with_border_style(BorderStyle::Unicode)
         .enable_squeezing(false)
-        .with_panels(2)
+        .num_panels(2)
         .build();
     printer.print_all(&input[..]).unwrap();
 }

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -340,7 +340,7 @@ fn run() -> Result<(), AnyhowError> {
         .show_char_panel(show_char_panel)
         .show_position_panel(show_position_panel)
         .with_border_style(border_style)
-        .with_squeeze(squeeze)
+        .enable_squeezing(squeeze)
         .with_panels(panels)
         .build();
     printer.display_offset(skip_offset + display_offset);

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -18,7 +18,7 @@ use thiserror::Error as ThisError;
 
 use terminal_size::terminal_size;
 
-use hexyl::{BorderStyle, Input, Printer};
+use hexyl::{BorderStyle, Input, PrinterBuilder};
 
 const DEFAULT_BLOCK_SIZE: i64 = 512;
 
@@ -335,15 +335,14 @@ fn run() -> Result<(), AnyhowError> {
     let stdout = io::stdout();
     let mut stdout_lock = stdout.lock();
 
-    let mut printer = Printer::new(
-        &mut stdout_lock,
-        show_color,
-        show_char_panel,
-        show_position_panel,
-        border_style,
-        squeeze,
-        panels,
-    );
+    let mut printer = PrinterBuilder::new(&mut stdout_lock)
+        .show_color(show_color)
+        .show_char_panel(show_char_panel)
+        .show_position_panel(show_position_panel)
+        .with_border_style(border_style)
+        .with_squeeze(squeeze)
+        .with_panels(panels)
+        .build();
     printer.display_offset(skip_offset + display_offset);
     printer.print_all(&mut reader).map_err(|e| anyhow!(e))?;
 

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -341,7 +341,7 @@ fn run() -> Result<(), AnyhowError> {
         .show_position_panel(show_position_panel)
         .with_border_style(border_style)
         .enable_squeezing(squeeze)
-        .with_panels(panels)
+        .num_panels(panels)
         .build();
     printer.display_offset(skip_offset + display_offset);
     printer.print_all(&mut reader).map_err(|e| anyhow!(e))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,11 +162,6 @@ impl<'a, Writer: Write> PrinterBuilder<'a, Writer> {
         }
     }
 
-    pub fn with_writer(mut self, writer: &'a mut Writer) -> PrinterBuilder<'a, Writer> {
-        self.writer = writer;
-        self
-    }
-
     pub fn show_color(mut self, show_color: bool) -> Self {
         self.show_color = show_color;
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,8 +187,8 @@ impl<'a, Writer: Write> PrinterBuilder<'a, Writer> {
         self
     }
 
-    pub fn with_panels(mut self, panels: u16) -> Self {
-        self.panels = panels;
+    pub fn num_panels(mut self, num: u16) -> Self {
+        self.panels = num;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,8 +182,8 @@ impl<'a, Writer: Write> PrinterBuilder<'a, Writer> {
         self
     }
 
-    pub fn with_squeeze(mut self, use_squeeze: bool) -> Self {
-        self.use_squeeze = use_squeeze;
+    pub fn enable_squeezing(mut self, enable: bool) -> Self {
+        self.use_squeeze = enable;
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,7 @@ struct BorderElements {
     right_corner: char,
 }
 
+#[derive(Clone, Copy)]
 pub enum BorderStyle {
     Unicode,
     Ascii,
@@ -138,6 +139,77 @@ impl BorderStyle {
     }
 }
 
+pub struct PrinterBuilder<'a, Writer: Write> {
+    writer: &'a mut Writer,
+    show_color: bool,
+    show_char_panel: bool,
+    show_position_panel: bool,
+    border_style: BorderStyle,
+    use_squeeze: bool,
+    panels: u16,
+}
+
+impl<'a, Writer: Write> PrinterBuilder<'a, Writer> {
+    pub fn new(writer: &'a mut Writer) -> Self {
+        PrinterBuilder {
+            writer,
+            show_color: true,
+            show_char_panel: true,
+            show_position_panel: true,
+            border_style: BorderStyle::Unicode,
+            use_squeeze: true,
+            panels: 2,
+        }
+    }
+
+    pub fn with_writer(mut self, writer: &'a mut Writer) -> PrinterBuilder<'a, Writer> {
+        self.writer = writer;
+        self
+    }
+
+    pub fn show_color(mut self, show_color: bool) -> Self {
+        self.show_color = show_color;
+        self
+    }
+
+    pub fn show_char_panel(mut self, show_char_panel: bool) -> Self {
+        self.show_char_panel = show_char_panel;
+        self
+    }
+
+    pub fn show_position_panel(mut self, show_position_panel: bool) -> Self {
+        self.show_position_panel = show_position_panel;
+        self
+    }
+
+    pub fn with_border_style(mut self, border_style: BorderStyle) -> Self {
+        self.border_style = border_style;
+        self
+    }
+
+    pub fn with_squeeze(mut self, use_squeeze: bool) -> Self {
+        self.use_squeeze = use_squeeze;
+        self
+    }
+
+    pub fn with_panels(mut self, panels: u16) -> Self {
+        self.panels = panels;
+        self
+    }
+
+    pub fn build(self) -> Printer<'a, Writer> {
+        Printer::new(
+            self.writer,
+            self.show_color,
+            self.show_char_panel,
+            self.show_position_panel,
+            self.border_style,
+            self.use_squeeze,
+            self.panels,
+        )
+    }
+}
+
 pub struct Printer<'a, Writer: Write> {
     idx: u64,
     /// The raw bytes used as input for the current line.
@@ -159,7 +231,7 @@ pub struct Printer<'a, Writer: Write> {
 }
 
 impl<'a, Writer: Write> Printer<'a, Writer> {
-    pub fn new(
+    fn new(
         writer: &'a mut Writer,
         show_color: bool,
         show_char_panel: bool,


### PR DESCRIPTION
As discussed in my previous pull request, this pull request deprecates using the new method directly on the `Printer` struct, preferring the `PrinterBuilder` struct for the builder pattern. This is a breaking change for `hexyl` as a library.