### PR TITLE
Update to `clap` 4

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -1,7 +1,7 @@
 name: CICD
 
 env:
-  MIN_SUPPORTED_RUST_VERSION: "1.56.1"
+  MIN_SUPPORTED_RUST_VERSION: "1.60.0"
   CICD_INTERMEDIATES_DIR: "_cicd-intermediates"
 
 on:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,26 +82,24 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "clap"
-version = "3.2.11"
+version = "4.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d646c7ade5eb07c4aa20e907a922750df0c448892513714fd3e4acbc7130829f"
+checksum = "0eb41c13df48950b20eb4cd0eefa618819469df1bffc49d11e8487c4ba0037e5"
 dependencies = [
  "atty",
  "bitflags",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "terminal_size 0.1.17",
- "textwrap",
+ "terminal_size",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -175,12 +173,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,18 +193,8 @@ dependencies = [
  "const_format",
  "libc",
  "predicates",
- "terminal_size 0.2.1",
+ "terminal_size",
  "thiserror",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
-dependencies = [
- "autocfg",
- "hashbrown",
 ]
 
 [[package]]
@@ -394,16 +376,6 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "terminal_size"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8440c860cf79def6164e4a0a983bcc2305d82419177a0e0c71930d049e3ac5a1"
@@ -417,15 +389,6 @@ name = "termtree"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
-dependencies = [
- "terminal_size 0.1.17",
-]
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,9 @@ thiserror = "1.0"
 terminal_size = "0.2"
 
 [dependencies.clap]
-version = "3"
+version = "4"
 default-features = false
-features = ["std", "suggestions", "color", "wrap_help", "cargo"]
+features = ["std", "suggestions", "color", "wrap_help", "cargo", "help", "usage", "error-context"]
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -102,7 +102,7 @@ fn run() -> Result<(), AnyhowError> {
                 .long("color")
                 .num_args(1)
                 .value_name("WHEN")
-                .possible_values(["always", "auto", "never"])
+                .value_parser(["always", "auto", "never"])
                 .default_value_if("plain", None, Some("never"))
                 .default_value("always")
                 .help(
@@ -118,7 +118,7 @@ fn run() -> Result<(), AnyhowError> {
                 .long("border")
                 .num_args(1)
                 .value_name("STYLE")
-                .possible_values(["unicode", "ascii", "none"])
+                .value_parser(["unicode", "ascii", "none"])
                 .default_value_if("plain", None, Some("none"))
                 .default_value("unicode")
                 .help(

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -112,9 +112,6 @@ fn run() -> Result<(), AnyhowError> {
                      goes to an interactive terminal",
                 ),
         )
-        .arg(Arg::new("plain").short('p').long("plain").action(ArgAction::SetTrue).help(
-            "Display output with --no-characters, --no-position, --border=none, and --color=never.",
-        ))
         .arg(
             Arg::new("border")
                 .long("border")
@@ -128,6 +125,9 @@ fn run() -> Result<(), AnyhowError> {
                     or none at all",
                 ),
         )
+        .arg(Arg::new("plain").short('p').long("plain").action(ArgAction::SetTrue).help(
+            "Display output with --no-characters, --no-position, --border=none, and --color=never.",
+        ))
         .arg(
             Arg::new("no_chars")
                 .short('C')
@@ -268,13 +268,13 @@ fn run() -> Result<(), AnyhowError> {
         reader.into_inner()
     };
 
-    let show_color = match matches.value_of("color") {
+    let show_color = match matches.get_one::<String>("color").map(String::as_ref) {
         Some("never") => false,
         Some("auto") => atty::is(Stream::Stdout),
         _ => true,
     };
 
-    let border_style = match matches.value_of("border") {
+    let border_style = match matches.get_one::<String>("border").map(String::as_ref) {
         Some("unicode") => BorderStyle::Unicode,
         Some("ascii") => BorderStyle::Ascii,
         _ => BorderStyle::None,
@@ -309,7 +309,7 @@ fn run() -> Result<(), AnyhowError> {
         }
     };
 
-    let panels = if matches.value_of("panels") == Some("auto") {
+    let panels = if matches.get_one::<String>("panels").map(String::as_ref) == Some("auto") {
         max_panels_fn(terminal_size().ok_or_else(|| anyhow!("not a TTY"))?.0 .0 as u64)
     } else if let Some(panels) = matches
         .get_one::<String>("panels")

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -181,13 +181,13 @@ fn run() -> Result<(), AnyhowError> {
 
     let stdin = io::stdin();
 
-    let mut reader = match matches.value_of("FILE") {
+    let mut reader = match matches.get_one::<String>("FILE") {
         Some(filename) => Input::File(File::open(filename)?),
         None => Input::Stdin(stdin.lock()),
     };
 
     let block_size = matches
-        .value_of("block_size")
+        .get_one::<String>("block_size")
         .map(|bs| {
             if let Some(hex_number) = try_parse_as_hex_number(bs) {
                 return hex_number.map_err(|e| anyhow!(e)).and_then(|x| {
@@ -212,7 +212,7 @@ fn run() -> Result<(), AnyhowError> {
         .unwrap_or_else(|| PositiveI64::new(DEFAULT_BLOCK_SIZE).unwrap());
 
     let skip_arg = matches
-        .value_of("skip")
+        .get_one::<String>("skip")
         .map(|s| {
             parse_byte_offset(s, block_size).context(anyhow!(
                 "failed to parse `--skip` arg {:?} as byte count",
@@ -248,9 +248,9 @@ fn run() -> Result<(), AnyhowError> {
     };
 
     let mut reader = if let Some(length) = matches
-        .value_of("length")
-        .or_else(|| matches.value_of("bytes"))
-        .or_else(|| matches.value_of("count"))
+        .get_one::<String>("length")
+        .or_else(|| matches.get_one::<String>("bytes"))
+        .or_else(|| matches.get_one::<String>("count"))
         .map(|s| {
             parse_byte_count(s).context(anyhow!(
                 "failed to parse `--length` arg {:?} as byte count",
@@ -283,7 +283,7 @@ fn run() -> Result<(), AnyhowError> {
     let show_position_panel = !matches.is_present("no_position") && !matches.is_present("plain");
 
     let display_offset: u64 = matches
-        .value_of("display_offset")
+        .get_one::<String>("display_offset")
         .map(|s| {
             parse_byte_count(s).context(anyhow!(
                 "failed to parse `--display-offset` arg {:?} as byte count",
@@ -306,7 +306,7 @@ fn run() -> Result<(), AnyhowError> {
     let panels = if matches.value_of("panels") == Some("auto") {
         max_panels_fn(terminal_size().ok_or_else(|| anyhow!("not a TTY"))?.0 .0 as u64)
     } else if let Some(panels) = matches
-        .value_of("panels")
+        .get_one::<String>("panels")
         .map(|s| {
             s.parse::<NonZeroU64>().map(u64::from).context(anyhow!(
                 "failed to parse `--panels` arg {:?} as unsigned nonzero integer",
@@ -317,7 +317,7 @@ fn run() -> Result<(), AnyhowError> {
     {
         panels
     } else if let Some(terminal_width) = matches
-        .value_of("terminal_width")
+        .get_one::<String>("terminal_width")
         .map(|s| {
             s.parse::<NonZeroU64>().map(u64::from).context(anyhow!(
                 "failed to parse `--terminal-width` arg {:?} as unsigned nonzero integer",

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -6,6 +6,7 @@ use std::fs::File;
 use std::io::{self, prelude::*, BufWriter, SeekFrom};
 use std::num::{NonZeroI64, NonZeroU64};
 
+use clap::builder::ArgPredicate;
 use clap::{crate_name, crate_version, Arg, ArgAction, ColorChoice, Command};
 
 use atty::Stream;
@@ -104,7 +105,7 @@ fn run() -> Result<(), AnyhowError> {
                 .num_args(1)
                 .value_name("WHEN")
                 .value_parser(["always", "auto", "never"])
-                .default_value_if("plain", None, Some("never"))
+                .default_value_if("plain", ArgPredicate::IsPresent, Some("never"))
                 .default_value("always")
                 .help(
                     "When to use colors. The auto-mode only displays colors if the output \
@@ -120,7 +121,7 @@ fn run() -> Result<(), AnyhowError> {
                 .num_args(1)
                 .value_name("STYLE")
                 .value_parser(["unicode", "ascii", "none"])
-                .default_value_if("plain", None, Some("none"))
+                .default_value_if("plain", ArgPredicate::IsPresent, Some("none"))
                 .default_value("unicode")
                 .help(
                     "Whether to draw a border with Unicode characters, ASCII characters, \

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -6,7 +6,7 @@ use std::fs::File;
 use std::io::{self, prelude::*, BufWriter, SeekFrom};
 use std::num::{NonZeroI64, NonZeroU64};
 
-use clap::{crate_name, crate_version, AppSettings, Arg, ColorChoice, Command};
+use clap::{crate_name, crate_version, Arg, ColorChoice, Command};
 
 use atty::Stream;
 
@@ -24,7 +24,6 @@ const DEFAULT_BLOCK_SIZE: i64 = 512;
 
 fn run() -> Result<(), AnyhowError> {
     let command = Command::new(crate_name!())
-        .setting(AppSettings::DeriveDisplayOrder)
         .color(ColorChoice::Auto)
         .max_term_width(90)
         .version(crate_version!())

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -6,7 +6,7 @@ use std::fs::File;
 use std::io::{self, prelude::*, BufWriter, SeekFrom};
 use std::num::{NonZeroI64, NonZeroU64};
 
-use clap::{crate_name, crate_version, Arg, ColorChoice, Command};
+use clap::{crate_name, crate_version, Arg, ArgAction, ColorChoice, Command};
 
 use atty::Stream;
 
@@ -91,6 +91,7 @@ fn run() -> Result<(), AnyhowError> {
             Arg::new("nosqueezing")
                 .short('v')
                 .long("no-squeezing")
+                .action(ArgAction::SetFalse)
                 .help(
                     "Displays all input data. Otherwise any number of groups of output \
                      lines which would be identical to the preceding group of lines, are \
@@ -110,7 +111,7 @@ fn run() -> Result<(), AnyhowError> {
                      goes to an interactive terminal",
                 ),
         )
-        .arg(Arg::new("plain").short('p').long("plain").help(
+        .arg(Arg::new("plain").short('p').long("plain").action(ArgAction::SetTrue).help(
             "Display output with --no-characters, --no-position, --border=none, and --color=never.",
         ))
         .arg(
@@ -130,12 +131,14 @@ fn run() -> Result<(), AnyhowError> {
             Arg::new("no_chars")
                 .short('C')
                 .long("no-characters")
+                .action(ArgAction::SetFalse)
                 .help("Whether to display the character panel on the right."),
         )
         .arg(
             Arg::new("no_position")
                 .short('P')
                 .long("no-position")
+                .action(ArgAction::SetFalse)
                 .help("Whether to display the position panel on the left."),
         )
         .arg(
@@ -276,11 +279,13 @@ fn run() -> Result<(), AnyhowError> {
         _ => BorderStyle::None,
     };
 
-    let squeeze = !matches.is_present("nosqueezing");
+    let &squeeze = matches.get_one::<bool>("nosqueezing").unwrap_or(&true);
 
-    let show_char_panel = !matches.is_present("no_chars") && !matches.is_present("plain");
+    let show_char_panel = *matches.get_one::<bool>("no_chars").unwrap_or(&true)
+        && !matches.get_one::<bool>("plain").unwrap_or(&false);
 
-    let show_position_panel = !matches.is_present("no_position") && !matches.is_present("plain");
+    let show_position_panel = *matches.get_one::<bool>("no_position").unwrap_or(&true)
+        && !matches.get_one::<bool>("plain").unwrap_or(&false);
 
     let display_offset: u64 = matches
         .get_one::<String>("display_offset")

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -61,7 +61,7 @@ fn run() -> Result<(), AnyhowError> {
                 .short('l')
                 .num_args(1)
                 .value_name("N")
-                .conflicts_with_all(&["length", "bytes"])
+                .conflicts_with_all(["length", "bytes"])
                 .hide(true)
                 .help("Yet another alias for -n/--length"),
         )
@@ -305,7 +305,7 @@ fn run() -> Result<(), AnyhowError> {
         if (terminal_width - offset) / col_width < 1 {
             1
         } else {
-            ((terminal_width - offset) / col_width) as u64
+            (terminal_width - offset) / col_width
         }
     };
 

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -36,7 +36,7 @@ fn run() -> Result<(), AnyhowError> {
             Arg::new("length")
                 .short('n')
                 .long("length")
-                .takes_value(true)
+                .num_args(1)
                 .value_name("N")
                 .help(
                     "Only read N bytes from the input. The N argument can also include a \
@@ -50,7 +50,7 @@ fn run() -> Result<(), AnyhowError> {
             Arg::new("bytes")
                 .short('c')
                 .long("bytes")
-                .takes_value(true)
+                .num_args(1)
                 .value_name("N")
                 .conflicts_with("length")
                 .help("An alias for -n/--length"),
@@ -58,7 +58,7 @@ fn run() -> Result<(), AnyhowError> {
         .arg(
             Arg::new("count")
                 .short('l')
-                .takes_value(true)
+                .num_args(1)
                 .value_name("N")
                 .conflicts_with_all(&["length", "bytes"])
                 .hide(true)
@@ -68,7 +68,7 @@ fn run() -> Result<(), AnyhowError> {
             Arg::new("skip")
                 .short('s')
                 .long("skip")
-                .takes_value(true)
+                .num_args(1)
                 .value_name("N")
                 .help(
                     "Skip the first N bytes of the input. The N argument can also include \
@@ -79,7 +79,7 @@ fn run() -> Result<(), AnyhowError> {
         .arg(
             Arg::new("block_size")
                 .long("block-size")
-                .takes_value(true)
+                .num_args(1)
                 .value_name("SIZE")
                 .help(formatcp!(
                     "Sets the size of the `block` unit to SIZE (default is {}).\n\
@@ -100,7 +100,7 @@ fn run() -> Result<(), AnyhowError> {
         .arg(
             Arg::new("color")
                 .long("color")
-                .takes_value(true)
+                .num_args(1)
                 .value_name("WHEN")
                 .possible_values(["always", "auto", "never"])
                 .default_value_if("plain", None, Some("never"))
@@ -116,7 +116,7 @@ fn run() -> Result<(), AnyhowError> {
         .arg(
             Arg::new("border")
                 .long("border")
-                .takes_value(true)
+                .num_args(1)
                 .value_name("STYLE")
                 .possible_values(["unicode", "ascii", "none"])
                 .default_value_if("plain", None, Some("none"))
@@ -142,7 +142,7 @@ fn run() -> Result<(), AnyhowError> {
             Arg::new("display_offset")
                 .short('o')
                 .long("display-offset")
-                .takes_value(true)
+                .num_args(1)
                 .value_name("N")
                 .help(
                     "Add N bytes to the displayed file position. The N argument can also \
@@ -154,7 +154,7 @@ fn run() -> Result<(), AnyhowError> {
         .arg(
             Arg::new("panels")
                 .long("panels")
-                .takes_value(true)
+                .num_args(1)
                 .value_name("N")
                 .help(
                     "Sets the number of hex data panels to be displayed. \
@@ -165,7 +165,7 @@ fn run() -> Result<(), AnyhowError> {
         .arg(
             Arg::new("terminal_width")
                 .long("terminal-width")
-                .takes_value(true)
+                .num_args(1)
                 .value_name("N")
                 .conflicts_with("panels")
                 .help(


### PR DESCRIPTION
The `clap` dependency is updated to 4.0, which required fixing breaking changes in the builder API. The MSRV must also be bumped to 1.60.0.