### PR TITLE
Support both little and big endian dump

### DIFF
--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -434,7 +434,9 @@ fn run() -> Result<()> {
         )
     };
 
-    let little_endian_dump = *matches.get_one::<bool>("little_endian_dump").unwrap_or(&false);
+    let little_endian_dump = *matches
+        .get_one::<bool>("little_endian_dump")
+        .unwrap_or(&false);
     let stdout = io::stdout();
     let mut stdout_lock = BufWriter::new(stdout.lock());
 

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -203,6 +203,15 @@ fn run() -> Result<()> {
                     width but still leave some space to the right.\nCannot be used with other \
                     width-setting options.",
                 ),
+        )
+        .arg(
+            Arg::new("little_endian_dump")
+                .short('e')
+                .action(ArgAction::SetTrue)
+                .help(
+                    "Print out the data in little endian format. Otherwise the data will be showed \
+                    in big endian format by default.",
+                ),
         );
 
     let matches = command.get_matches();
@@ -425,6 +434,7 @@ fn run() -> Result<()> {
         )
     };
 
+    let little_endian_dump = *matches.get_one::<bool>("little_endian_dump").unwrap_or(&false);
     let stdout = io::stdout();
     let mut stdout_lock = BufWriter::new(stdout.lock());
 
@@ -437,6 +447,7 @@ fn run() -> Result<()> {
         .num_panels(panels)
         .group_size(group_size)
         .with_base(base)
+        .little_endian_dump(little_endian_dump)
         .build();
     printer.display_offset(skip_offset + display_offset);
     printer.print_all(&mut reader).map_err(|e| anyhow!(e))?;

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -209,7 +209,7 @@ fn run() -> Result<()> {
                 .short('e')
                 .action(ArgAction::SetTrue)
                 .help(
-                    "Print out the data in little endian format. Otherwise the data will be showed \
+                    "Print out the data in little endian format. Otherwise the data will be shown \
                     in big endian format by default.",
                 ),
         );

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -190,8 +190,17 @@ fn run() -> Result<()> {
                 .help(
                     "Whether to print out groups in little-endian or big-endian \
                      format. This option only has an effect if the '--group-size' \
-                     is larger than 1.",
+                     is larger than 1. '-e' can be used as an alias for \
+                     '--endianness=little'.",
                 ),
+        )
+        .arg(
+            Arg::new("little_endian_format")
+                .short('e')
+                .action(ArgAction::SetTrue)
+                .overrides_with("endianness")
+                .hide(true)
+                .help("An alias for '--endianness=little'."),
         )
         .arg(
             Arg::new("base")
@@ -440,9 +449,14 @@ fn run() -> Result<()> {
         )
     };
 
-    let endianness = match matches.get_one::<String>("endianness").map(String::as_ref) {
-        Some("little") => Endianness::Little,
-        Some("big") => Endianness::Big,
+    let little_endian_format = *matches.get_one::<bool>("little_endian_format").unwrap();
+    let endianness = matches.get_one::<String>("endianness");
+    let endianness = match (
+        endianness.map(|s| s.as_ref()).unwrap(),
+        little_endian_format,
+    ) {
+        (_, true) | ("little", _) => Endianness::Little,
+        ("big", _) => Endianness::Big,
         _ => unreachable!(),
     };
     let stdout = io::stdout();

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -174,8 +174,23 @@ fn run() -> Result<()> {
                 .value_name("N")
                 .help(
                     "Number of bytes/octets that should be grouped together. \
-                    Possible group sizes are 1, 2, 4, 8. The default is 1. \
-                    '--groupsize can be used as an alias (xxd-compatibility).",
+                    Possible group sizes are 1, 2, 4, 8. The default is 1. You \
+                    can use the '--endianness' option to control the ordering of \
+                    the bytes within a group. '--groupsize' can be used as an \
+                    alias (xxd-compatibility).",
+                ),
+        )
+        .arg(
+            Arg::new("endianness")
+                .long("endianness")
+                .num_args(1)
+                .value_name("FORMAT")
+                .value_parser(["big", "little"])
+                .default_value("big")
+                .help(
+                    "Whether to print out groups in little-endian or big-endian \
+                     format. This option only has an effect if the '--group-size' \
+                     is larger than 1.",
                 ),
         )
         .arg(
@@ -202,18 +217,6 @@ fn run() -> Result<()> {
                     will use the greatest number of hex data panels that can fit in the requested \
                     width but still leave some space to the right.\nCannot be used with other \
                     width-setting options.",
-                ),
-        )
-        .arg(
-            Arg::new("endianness")
-                .long("endianness")
-                .requires("group_size")
-                .num_args(1)
-                .value_name("ENDIANNESS")
-                .value_parser(["big", "little"])
-                .default_value("big")
-                .help(
-                    "Whether to print out the data in little endian format or big endian format.",
                 ),
         );
 

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -17,7 +17,7 @@ use thiserror::Error as ThisError;
 
 use terminal_size::terminal_size;
 
-use hexyl::{Base, BorderStyle, Input, PrinterBuilder};
+use hexyl::{Base, BorderStyle, Endianness, Input, PrinterBuilder};
 
 const DEFAULT_BLOCK_SIZE: i64 = 512;
 
@@ -434,9 +434,13 @@ fn run() -> Result<()> {
         )
     };
 
-    let little_endian_dump = *matches
+    let endianness = match *matches
         .get_one::<bool>("little_endian_dump")
-        .unwrap_or(&false);
+        .unwrap_or(&false)
+    {
+        true => Endianness::Little,
+        false => Endianness::Big,
+    };
     let stdout = io::stdout();
     let mut stdout_lock = BufWriter::new(stdout.lock());
 
@@ -449,7 +453,7 @@ fn run() -> Result<()> {
         .num_panels(panels)
         .group_size(group_size)
         .with_base(base)
-        .little_endian_dump(little_endian_dump)
+        .endianness(endianness)
         .build();
     printer.display_offset(skip_offset + display_offset);
     printer.print_all(&mut reader).map_err(|e| anyhow!(e))?;

--- a/src/bin/hexyl.rs
+++ b/src/bin/hexyl.rs
@@ -205,12 +205,15 @@ fn run() -> Result<()> {
                 ),
         )
         .arg(
-            Arg::new("little_endian_dump")
-                .short('e')
-                .action(ArgAction::SetTrue)
+            Arg::new("endianness")
+                .long("endianness")
+                .requires("group_size")
+                .num_args(1)
+                .value_name("ENDIANNESS")
+                .value_parser(["big", "little"])
+                .default_value("big")
                 .help(
-                    "Print out the data in little endian format. Otherwise the data will be shown \
-                    in big endian format by default.",
+                    "Whether to print out the data in little endian format or big endian format.",
                 ),
         );
 
@@ -434,12 +437,10 @@ fn run() -> Result<()> {
         )
     };
 
-    let endianness = match *matches
-        .get_one::<bool>("little_endian_dump")
-        .unwrap_or(&false)
-    {
-        true => Endianness::Little,
-        false => Endianness::Big,
+    let endianness = match matches.get_one::<String>("endianness").map(String::as_ref) {
+        Some("little") => Endianness::Little,
+        Some("big") => Endianness::Big,
+        _ => unreachable!(),
     };
     let stdout = io::stdout();
     let mut stdout_lock = BufWriter::new(stdout.lock());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -718,7 +718,7 @@ mod tests {
             2,
             1,
             Base::Hexadecimal,
-            false,
+            Endianness::Big,
         );
 
         printer.print_all(input).unwrap();
@@ -773,7 +773,7 @@ mod tests {
             2,
             1,
             Base::Hexadecimal,
-            false,
+            Endianness::Big,
         );
         printer.display_offset(0xdeadbeef);
 
@@ -807,7 +807,7 @@ mod tests {
             4,
             1,
             Base::Hexadecimal,
-            false,
+            Endianness::Big,
         );
 
         printer.print_all(input).unwrap();
@@ -867,7 +867,7 @@ mod tests {
             3,
             1,
             Base::Hexadecimal,
-            false,
+            Endianness::Big,
         );
 
         printer.print_all(input).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,7 +540,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
         Ok(())
     }
 
-    fn reorder_buf_to_little_endian(&self, buf: &mut Vec<u8>) {
+    fn reorder_buffer_to_little_endian(&self, buf: &mut Vec<u8>) {
         let n = buf.len();
         let group_sz = self.group_size as usize;
 
@@ -556,8 +556,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
         let mut buf = self.line_buf.clone();
 
         if matches!(self.endianness, Endianness::Little) {
-            // reorder the buffer to the little endian format
-            self.reorder_buf_to_little_endian(&mut buf);
+            self.reorder_buffer_to_little_endian(&mut buf);
         };
 
         for (i, &b) in buf.iter().enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,7 +267,7 @@ pub struct Printer<'a, Writer: Write> {
     group_size: u8,
     /// The number of digits used to write the base.
     base_digits: u8,
-    /// Whether to print the bytes in little endian
+    /// Whether to show groups in little or big endian ordering.
     endianness: Endianness,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -543,7 +543,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
             let remaining = n - idx;
             let total = remaining.min(group_sz);
 
-            buf[idx..idx+total].reverse();
+            buf[idx..idx + total].reverse();
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -540,7 +540,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
         Ok(())
     }
 
-    fn reorder_buf_to_le(&self, buf: &mut Vec<u8>) {
+    fn reorder_buf_to_little_endian(&self, buf: &mut Vec<u8>) {
         let n = buf.len();
         let group_sz = self.group_size as usize;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,7 +557,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
 
         if matches!(self.endianness, Endianness::Little) {
             // reorder the buffer to the little endian format
-            self.reorder_buf_to_le(&mut buf);
+            self.reorder_buf_to_little_endian(&mut buf);
         };
 
         for (i, &b) in buf.iter().enumerate() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,11 @@ pub enum ByteCategory {
     NonAscii,
 }
 
+pub enum Endianness {
+    Little,
+    Big,
+}
+
 #[derive(PartialEq)]
 enum Squeezer {
     Print,
@@ -159,7 +164,7 @@ pub struct PrinterBuilder<'a, Writer: Write> {
     panels: u64,
     group_size: u8,
     base: Base,
-    little_endian_dump: bool,
+    endianness: Endianness,
 }
 
 impl<'a, Writer: Write> PrinterBuilder<'a, Writer> {
@@ -174,7 +179,7 @@ impl<'a, Writer: Write> PrinterBuilder<'a, Writer> {
             panels: 2,
             group_size: 1,
             base: Base::Hexadecimal,
-            little_endian_dump: false,
+            endianness: Endianness::Big,
         }
     }
 
@@ -218,8 +223,8 @@ impl<'a, Writer: Write> PrinterBuilder<'a, Writer> {
         self
     }
 
-    pub fn little_endian_dump(mut self, little_endian_dump: bool) -> Self {
-        self.little_endian_dump = little_endian_dump;
+    pub fn endianness(mut self, endianness: Endianness) -> Self {
+        self.endianness = endianness;
         self
     }
 
@@ -234,7 +239,7 @@ impl<'a, Writer: Write> PrinterBuilder<'a, Writer> {
             self.panels,
             self.group_size,
             self.base,
-            self.little_endian_dump,
+            self.endianness,
         )
     }
 }
@@ -263,7 +268,7 @@ pub struct Printer<'a, Writer: Write> {
     /// The number of digits used to write the base.
     base_digits: u8,
     /// Whether to print the bytes in little endian
-    little_endian_dump: bool,
+    endianness: Endianness,
 }
 
 impl<'a, Writer: Write> Printer<'a, Writer> {
@@ -277,7 +282,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
         panels: u64,
         group_size: u8,
         base: Base,
-        little_endian_dump: bool,
+        endianness: Endianness,
     ) -> Printer<'a, Writer> {
         Printer {
             idx: 0,
@@ -315,7 +320,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
                 Base::Decimal => 3,
                 Base::Hexadecimal => 2,
             },
-            little_endian_dump,
+            endianness,
         }
     }
 
@@ -550,7 +555,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
     pub fn print_bytes(&mut self) -> io::Result<()> {
         let mut buf = self.line_buf.clone();
 
-        if self.little_endian_dump {
+        if matches!(self.endianness, Endianness::Little) {
             // reorder the buffer to the little endian format
             self.reorder_buf_to_le(&mut buf);
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,7 +267,7 @@ pub struct Printer<'a, Writer: Write> {
     group_size: u8,
     /// The number of digits used to write the base.
     base_digits: u8,
-    /// Whether to show groups in little or big endian ordering.
+    /// Whether to show groups in little or big endian format.
     endianness: Endianness,
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -292,12 +292,12 @@ mod display_settings {
     }
 }
 
-mod group {
+mod group_and_endian {
     use super::hexyl;
     use super::PrettyAssert;
 
     #[test]
-    fn group_2_bytes() {
+    fn group_2_bytes_be() {
         hexyl()
             .arg("ascii")
             .arg("--color=never")
@@ -312,7 +312,23 @@ mod group {
     }
 
     #[test]
-    fn group_4_bytes() {
+    fn group_2_bytes_le() {
+        hexyl()
+            .arg("ascii")
+            .arg("--color=never")
+            .arg("--group-size=2")
+            .arg("-e")
+            .assert()
+            .success()
+            .stdout(
+                "┌────────┬─────────────────────┬─────────────────────┬────────┬────────┐\n\
+                 │00000000│ 3130 3332 3534 3736 ┊ 3938 6261 6463 0a65 │01234567┊89abcde_│\n\
+                 └────────┴─────────────────────┴─────────────────────┴────────┴────────┘\n",
+            );
+    }
+
+    #[test]
+    fn group_4_bytes_be() {
         hexyl()
             .arg("ascii")
             .arg("--color=never")
@@ -327,7 +343,23 @@ mod group {
     }
 
     #[test]
-    fn group_8_bytes() {
+    fn group_4_bytes_le() {
+        hexyl()
+            .arg("ascii")
+            .arg("--color=never")
+            .arg("--group-size=4")
+            .arg("-e")
+            .assert()
+            .success()
+            .stdout(
+                "┌────────┬───────────────────┬───────────────────┬────────┬────────┐\n\
+                 │00000000│ 33323130 37363534 ┊ 62613938 0a656463 │01234567┊89abcde_│\n\
+                 └────────┴───────────────────┴───────────────────┴────────┴────────┘\n",
+            );
+    }
+
+    #[test]
+    fn group_8_bytes_be() {
         hexyl()
             .arg("ascii")
             .arg("--color=never")
@@ -337,6 +369,22 @@ mod group {
             .stdout(
                 "┌────────┬──────────────────┬──────────────────┬────────┬────────┐\n\
                  │00000000│ 3031323334353637 ┊ 383961626364650a │01234567┊89abcde_│\n\
+                 └────────┴──────────────────┴──────────────────┴────────┴────────┘\n",
+            );
+    }
+
+    #[test]
+    fn group_8_bytes_le() {
+        hexyl()
+            .arg("ascii")
+            .arg("--color=never")
+            .arg("--group-size=8")
+            .arg("-e")
+            .assert()
+            .success()
+            .stdout(
+                "┌────────┬──────────────────┬──────────────────┬────────┬────────┐\n\
+                 │00000000│ 3736353433323130 ┊ 0a65646362613938 │01234567┊89abcde_│\n\
                  └────────┴──────────────────┴──────────────────┴────────┴────────┘\n",
             );
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -317,7 +317,7 @@ mod group_and_endianness {
             .arg("ascii")
             .arg("--color=never")
             .arg("--group-size=2")
-            .arg("-e")
+            .arg("--endianness=little")
             .assert()
             .success()
             .stdout(
@@ -348,7 +348,7 @@ mod group_and_endianness {
             .arg("ascii")
             .arg("--color=never")
             .arg("--group-size=4")
-            .arg("-e")
+            .arg("--endianness=little")
             .assert()
             .success()
             .stdout(
@@ -379,7 +379,7 @@ mod group_and_endianness {
             .arg("ascii")
             .arg("--color=never")
             .arg("--group-size=8")
-            .arg("-e")
+            .arg("--endianness=little")
             .assert()
             .success()
             .stdout(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -292,7 +292,7 @@ mod display_settings {
     }
 }
 
-mod group_and_endian {
+mod group_and_endianness {
     use super::hexyl;
     use super::PrettyAssert;
 


### PR DESCRIPTION
In #170, we solve a part of the demand for #104, which provided the option to group bytes.  In this patch, I am trying to complete the remaining requirement for endianness.

