### PR TITLE
Correctly handle discontinuous input i.e. stdin

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -585,7 +585,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
                     }
                     let mut leftover = n;
                     // loop until input is ceased
-                    break loop {
+                    if let Some(s) = loop {
                         if let Ok(n) = buf.read(&mut self.line_buf[leftover..]) {
                             leftover += n;
                             // there is no more input being read
@@ -595,15 +595,11 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
                             }
                             // amount read has exceeded line buffer
                             if leftover >= 8 * self.panels as usize {
-                                self.print_position_panel()?;
-                                self.print_bytes()?;
-                                if self.show_char_panel {
-                                    self.print_char_panel()?;
-                                }
-                                self.writer.write_all(b"\n")?;
-                                leftover = 0;
+                                break None;
                             }
                         }
+                    } {
+                        break Some(s);
                     };
                 } else if n == 0 {
                     // if no bytes are read, that indicates end of file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -584,7 +584,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
                         is_empty = false;
                     }
                     let mut leftover = n;
-                    // loop until
+                    // loop until input is ceased
                     break loop {
                         if let Ok(n) = buf.read(&mut self.line_buf[leftover..]) {
                             leftover += n;


### PR DESCRIPTION
Fixes #196.

This PR properly handles the case when the reader is still available after returning an incomplete amount of data. When I initially rewrote the architecture of `hexyl`, I only handled spurious incomplete reads by adding a second check. However, `stdin` is a reader that can return incomplete reads multiple times.

This PR changes the second check to a loop that repeatedly reads until either the line buffer is filled or the reader is exhausted.