### PR TITLE
fix arch linux repo link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ sudo dnf install hexyl
 
 ### On Arch Linux
 
-You can install `hexyl` from [the official package repository](https://www.archlinux.org/packages/community/x86_64/hexyl/):
+You can install `hexyl` from [the official package repository](https://archlinux.org/packages/extra/x86_64/hexyl/):
 
 ```
 pacman -S hexyl


### PR DESCRIPTION
> The [community] repository will be merged into [extra] and will therefore be empty after the migration.

[source](https://archlinux.org/news/git-migration-announcement/)