### PR TITLE
Squeeze identical lines

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub enum Endianness {
     Big,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(PartialEq)]
 enum Squeezer {
     Print,
     Delete,
@@ -657,7 +657,6 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
                         continue;
                     }
                 } else {
-                    write!(self.writer, "self")?;
                     self.squeezer = Squeezer::Ignore;
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -934,4 +934,41 @@ mod tests {
         let actual_string: &str = str::from_utf8(&output).unwrap();
         assert_eq!(actual_string, expected_string)
     }
+
+    #[test]
+    fn identical_lines() {
+        let input = io::Cursor::new(
+            "abcdefg\ngfedcba\nhijklmn\nhijklmn\nhijklmn\nhijklmn\nopqrstu\nvwxyzab\n",
+        );
+        let expected_string = "\
+┌────────┬─────────────────────────┬────────┐
+│00000000│ 61 62 63 64 65 66 67 0a │abcdefg_│
+│00000008│ 67 66 65 64 63 62 61 0a │gfedcba_│
+│00000010│ 68 69 6a 6b 6c 6d 6e 0a │hijklmn_│
+│*       │                         │        │
+│00000030│ 6f 70 71 72 73 74 75 0a │opqrstu_│
+│00000038│ 76 77 78 79 7a 61 62 0a │vwxyzab_│
+└────────┴─────────────────────────┴────────┘
+"
+        .to_owned();
+        let mut output = vec![];
+        let mut printer: Printer<Vec<u8>> = Printer::new(
+            &mut output,
+            false,
+            true,
+            true,
+            BorderStyle::Unicode,
+            true,
+            1,
+            1,
+            Base::Hexadecimal,
+            Endianness::Big,
+            CharacterTable::Default,
+        );
+
+        printer.print_all(input).unwrap();
+
+        let actual_string: &str = str::from_utf8(&output).unwrap();
+        assert_eq!(actual_string, expected_string)
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -634,14 +634,6 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
                 self.print_header()?;
             }
 
-            // write!(self.writer, "{:?}", self.squeezer)?;
-            //write!(self.writer, "{:?}", self.squeeze_line)?;
-            // write!(
-            //     self.writer,
-            //     "{:#X} {:#X}",
-            //     self.squeeze_line[0], self.line_buf[0]
-            // )?;
-
             // squeeze is active, check if the line is the same
             // skip print if still squeezed, otherwise print and deactivate squeeze
             if matches!(self.squeezer, Squeezer::Print | Squeezer::Delete) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -729,8 +729,8 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
             writeln!(self.writer)?;
         } else if let Some(n) = leftover {
             // last line is incomplete
-            self.print_position_panel()?;
             self.squeezer = Squeezer::Ignore;
+            self.print_position_panel()?;
             self.print_bytes()?;
             self.squeezer = Squeezer::Print;
             for i in n..8 * self.panels as usize {


### PR DESCRIPTION
Fixes #186.

This brings the squeezing feature to parity with `hexdump`. Lines that contain identical data should be squeezed, not just when they are all filled with a single byte.