### PR TITLE
Fixes the Squeezing bug (see #186)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 
 ## Bugfixes
-
+- Now also squeezes identical lines that are not a single repeating byte, see #186 (@Taraxtix)
 
 ## Other
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -631,15 +631,17 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
             if is_empty {
                 self.print_header()?;
             }
-            
+
             if self.line_buf == self.last_line {
                 match self.squeezer {
-                    Squeezer::Delete => {self.idx += 8 * self.panels;
-                        continue;}
+                    Squeezer::Delete => {
+                        self.idx += 8 * self.panels;
+                        continue;
+                    }
                     Squeezer::Ignore => self.squeezer = Squeezer::Print,
                     Squeezer::Print | Squeezer::Disabled => (),
                 }
-            }else{
+            } else {
                 match self.squeezer {
                     Squeezer::Delete | Squeezer::Print => self.squeezer = Squeezer::Ignore,
                     Squeezer::Ignore | Squeezer::Disabled => (),


### PR DESCRIPTION
Now identical lines that are not a single repeating byte are properly squeezed.
I also added a test case for this behavior.