### PR TITLE
deps: bump libc from 0.2.147 to 0.2.155

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "linux-raw-sys"


### PR DESCRIPTION
Add dependencies that support the loongarch64 architecture [rust-lang/libc#2765](https://github.com/rust-lang/libc/pull/2765)