### PR TITLE
docs(install): add x-cmd method to install hexyl

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,10 @@ sudo snap install hexyl
 scoop install hexyl
 ```
 
+### Via [X-CMD](https://x-cmd.com)
+```
+x env use hexyl
+```
 
 ## License
 


### PR DESCRIPTION
- Hi, [x-cmd](https://www.x-cmd.com/) is a **toolbox for Posix Shell**, offering a lightweight package manager built using shell and awk.. It helps you download hexyl release packages from the internet and extract them into a unified directory for management, without requiring root permissions.

- **I mean, can the installation method provided by x-cmd be added to the hexyl README.md?**[The installation method for the x command](https://www.x-cmd.com/start/).
  ```sh
  x env use hexyl
  ```

- We wrote a [hexyl introduction article](https://www.x-cmd.com/pkg/hexyl) and a [demo](https://www.bilibili.com/video/BV1rAyPYYEzn/)