### PR TITLE
Fix some clippy warnings

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -6,7 +6,7 @@ pub enum Input<'a> {
     Stdin(io::StdinLock<'a>),
 }
 
-impl<'a> Read for Input<'a> {
+impl Read for Input<'_> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match *self {
             Input::File(ref mut file) => file.read(buf),
@@ -15,7 +15,7 @@ impl<'a> Read for Input<'a> {
     }
 }
 
-impl<'a> Seek for Input<'a> {
+impl Seek for Input<'_> {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
         fn try_skip<R>(reader: R, pos: SeekFrom, err_desc: &'static str) -> io::Result<u64>
         where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -445,7 +445,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
         if self.show_position_panel {
             match self.squeezer {
                 Squeezer::Print => {
-                    self.writer.write_all(&[b'*'])?;
+                    self.writer.write_all(b"*")?;
                     if self.show_color {
                         self.writer.write_all(COLOR_RESET)?;
                     }
@@ -585,7 +585,7 @@ impl<'a, Writer: Write> Printer<'a, Writer> {
         Ok(())
     }
 
-    fn reorder_buffer_to_little_endian(&self, buf: &mut Vec<u8>) {
+    fn reorder_buffer_to_little_endian(&self, buf: &mut [u8]) {
         let n = buf.len();
         let group_sz = self.group_size as usize;
 


### PR DESCRIPTION
Changes:
- Elid lifetimes when possible
- Use a slice instead of a Vec as function argument
- Rewrite &[b'\*''] as b"\*"