### PR TITLE
Check if terminal_width is less than offset and return 1 (see #244)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # unreleased 
 
+- Fix memory allocation bug when terminal width is less than 10, see #244 (@selfup)
+
 ## Features
 
 ## Bugfixes

--- a/src/main.rs
+++ b/src/main.rs
@@ -362,12 +362,7 @@ fn run() -> Result<()> {
         } else {
             ((8 / group_size) * (base_digits * group_size + 1)) + 2
         };
-
-        if terminal_width < offset {
-            return 1;
-        }
-
-        if (terminal_width - offset) / col_width < 1 {
+        if (terminal_width.saturating_sub(offset)) / col_width < 1 {
             1
         } else {
             (terminal_width - offset) / col_width

--- a/src/main.rs
+++ b/src/main.rs
@@ -362,7 +362,10 @@ fn run() -> Result<()> {
         } else {
             ((8 / group_size) * (base_digits * group_size + 1)) + 2
         };
-        if (terminal_width - offset) / col_width < 1 {
+
+        if terminal_width < offset {
+            1
+        } else if (terminal_width - offset) / col_width < 1 {
             1
         } else {
             (terminal_width - offset) / col_width

--- a/src/main.rs
+++ b/src/main.rs
@@ -364,8 +364,10 @@ fn run() -> Result<()> {
         };
 
         if terminal_width < offset {
-            1
-        } else if (terminal_width - offset) / col_width < 1 {
+            return 1;
+        }
+
+        if (terminal_width - offset) / col_width < 1 {
             1
         } else {
             (terminal_width - offset) / col_width


### PR DESCRIPTION
In issue #244 a bug of what seems to be an underflow has been found when the terminal-width is quite small.

```console
--terminal-width 2 <(echo "test")
memory allocation of 4340410370284600376 bytes failed
```

I added a simple check in `max_panels_fn`.

Here is the fix working:

```console
$ cargo run -- --terminal-width 2 <(echo "test")
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running `target/debug/hexyl --terminal-width 2 /dev/fd/11`
┌────────┬─────────────────────────┬────────┐
│00000000│ 74 65 73 74 0a          │test_   │
└────────┴─────────────────────────┴────────┘
```

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/0d769ee1-e9b3-494d-bbfe-1fee007d6ba5" />

---

`cargo test` still passes (omitted noise):

```
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 38 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.19s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Time to see if CI passes as well.

Let me know if there are any other checks we'd like to do outside of existing tests/CI.

Thanks!