### PR TITLE
Add option to output result in C include file style (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Features
 
+- Add option to output result in C include file style, see #242 (@wpcwzy)
+
 ## Bugfixes
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,7 @@ pub struct Printer<'a, Writer: Write> {
 }
 
 impl<'a, Writer: Write> Printer<'a, Writer> {
+    #![allow(clippy::too_many_arguments)]
     fn new(
         writer: &'a mut Writer,
         show_color: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,11 +189,13 @@ struct Opt {
     #[arg(long)]
     print_color_table: bool,
 
-    /// Output in C/Rust-style array format (similar to xxd -i).
+    /// Output in C include file style (similar to xxd -i).
     #[arg(
         short('i'),
         long("include"),
-        help = "Output in a format suitable for including in a C/Rust program"
+        help = "Output in C include file style",
+        conflicts_with("little_endian_format"),
+        conflicts_with("endianness")
     )]
     include_mode: bool,
 }


### PR DESCRIPTION
This pull request introduces a new feature that adds an option to output the result in C include file style, similar to the `-i` or `--include` option of the `xxd` command. This functionality allows users to generate hex dumps in a format that can be easily embedded as arrays in various programming languages.

When `hexyl` accepts input from stdin, users can expect the following output format:
```bash
$ echo -n "Hello, world!" | hexyl -i
  0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64,
  0x21
```

When `hexyl` accepts a filename as an argument and reads from the file, users can expect the following output format:
```bash
$ hexyl -i hello.txt
unsigned char hello_txt[] = {
  0x48, 0x65, 0x6c, 0x6c, 0x6f, 0x2c, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64,
  0x21
};
unsigned int hello_txt_len = 13;
```

The above behavior is consistent with the behavior of `xxd -i`.

I also added the functionality to accept input from a slice and output the bytes in C include file style, as I noticed that there is a corresponding use case in `examples/simple.rs`. When `hexyl` accepts input from a slice, its behavior is consistent with accepting input from stdin.

This is my first time contributing a new feature to an open-source project, so if there are any areas where I may have fallen short or could improve, I would really appreciate your feedback. Thank you!