### PR TITLE
Add new braille character table and color schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Features
 
+- Add `--color-scheme` option, see #247 (@aticu)
+- Add `braille` character table, see #247 (@aticu)
+
 ## Bugfixes
 
 

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -10,7 +10,7 @@ pub const COLOR_RESET: &[u8] = colors::Default::ANSI_FG.as_bytes();
 
 pub const COLOR_NULL_RGB: &[u8] = &rgb_bytes(100, 100, 100);
 
-pub const COLOR_DEL: &[u8] = &rgb_bytes(0, 255, 255);
+pub const COLOR_DEL: &[u8] = &rgb_bytes(64, 128, 0);
 
 pub const COLOR_GRADIENT_NONASCII: [[u8; 19]; 128] =
     generate_color_gradient(&[(255, 0, 0, 0.0), (255, 255, 0, 0.66), (255, 255, 255, 1.0)]);

--- a/src/colors.rs
+++ b/src/colors.rs
@@ -8,6 +8,81 @@ pub const COLOR_ASCII_OTHER: &[u8] = colors::Green::ANSI_FG.as_bytes();
 pub const COLOR_NONASCII: &[u8] = colors::Yellow::ANSI_FG.as_bytes();
 pub const COLOR_RESET: &[u8] = colors::Default::ANSI_FG.as_bytes();
 
+pub const COLOR_NULL_RGB: &[u8] = &rgb_bytes(100, 100, 100);
+
+pub const COLOR_DEL: &[u8] = &rgb_bytes(0, 255, 255);
+
+pub const COLOR_GRADIENT_NONASCII: [[u8; 19]; 128] =
+    generate_color_gradient(&[(255, 0, 0, 0.0), (255, 255, 0, 0.66), (255, 255, 255, 1.0)]);
+
+pub const COLOR_GRADIENT_ASCII_NONPRINTABLE: [[u8; 19]; 31] =
+    generate_color_gradient(&[(255, 0, 255, 0.0), (128, 0, 255, 1.0)]);
+
+pub const COLOR_GRADIENT_ASCII_PRINTABLE: [[u8; 19]; 95] =
+    generate_color_gradient(&[(0, 128, 255, 0.0), (0, 255, 128, 1.0)]);
+
+const fn as_dec(byte: u8) -> [u8; 3] {
+    [
+        b'0' + (byte / 100),
+        b'0' + ((byte % 100) / 10),
+        b'0' + (byte % 10),
+    ]
+}
+
+const fn rgb_bytes(r: u8, g: u8, b: u8) -> [u8; 19] {
+    let mut buf = *b"\x1b[38;2;rrr;ggg;bbbm";
+
+    // r 7
+    buf[7] = as_dec(r)[0];
+    buf[8] = as_dec(r)[1];
+    buf[9] = as_dec(r)[2];
+
+    // g 11
+    buf[11] = as_dec(g)[0];
+    buf[12] = as_dec(g)[1];
+    buf[13] = as_dec(g)[2];
+
+    // b 15
+    buf[15] = as_dec(b)[0];
+    buf[16] = as_dec(b)[1];
+    buf[17] = as_dec(b)[2];
+
+    buf
+}
+
+const fn generate_color_gradient<const N: usize>(stops: &[(u8, u8, u8, f64)]) -> [[u8; 19]; N] {
+    let mut out = [rgb_bytes(0, 0, 0); N];
+
+    assert!(stops.len() >= 2, "need at least two stops for the gradient");
+
+    let mut byte = 0;
+    while byte < N {
+        let relative_byte = byte as f64 / N as f64;
+
+        let mut i = 1;
+        while i < stops.len() && stops[i].3 < relative_byte {
+            i += 1;
+        }
+        if i >= stops.len() {
+            i = stops.len() - 1;
+        }
+        let prev_stop = stops[i - 1];
+        let stop = stops[i];
+        let diff = stop.3 - prev_stop.3;
+        let t = (relative_byte - prev_stop.3) / diff;
+
+        let r = (prev_stop.0 as f64 + (t * (stop.0 as f64 - prev_stop.0 as f64))) as u8;
+        let g = (prev_stop.1 as f64 + (t * (stop.1 as f64 - prev_stop.1 as f64))) as u8;
+        let b = (prev_stop.2 as f64 + (t * (stop.2 as f64 - prev_stop.2 as f64))) as u8;
+
+        out[byte] = rgb_bytes(r, g, b);
+
+        byte += 1;
+    }
+
+    out
+}
+
 #[rustfmt::skip]
 pub const CP437: [char; 256] = [
     // Copyright (c) 2016, Delan Azabani <delan@azabani.com>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,8 @@ impl Byte {
                 Null => '⋄',
                 AsciiPrintable => self.0 as char,
                 AsciiWhitespace if self.0 == b' ' => ' ',
-                // \n and \r are important enough to get their own symbols
+                // `\t`, `\n` and `\r` are important enough to get their own symbols
+                AsciiWhitespace if self.0 == b'\t' => '→',
                 AsciiWhitespace if self.0 == b'\n' => '↵',
                 AsciiWhitespace if self.0 == b'\r' => '←',
                 AsciiWhitespace | AsciiOther | NonAscii => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use thiserror::Error as ThisError;
 
 use terminal_size::terminal_size;
 
-use hexyl::{Base, BorderStyle, CharacterTable, Endianness, Input, PrinterBuilder};
+use hexyl::{Base, BorderStyle, CharacterTable, ColorScheme, Endianness, Input, PrinterBuilder};
 
 use hexyl::{
     COLOR_ASCII_OTHER, COLOR_ASCII_PRINTABLE, COLOR_ASCII_WHITESPACE, COLOR_NONASCII, COLOR_NULL,
@@ -128,6 +128,10 @@ struct Opt {
     /// Defines how bytes are mapped to characters.
     #[arg(long, value_enum, default_value_t, value_name("FORMAT"))]
     character_table: CharacterTable,
+
+    /// Defines the color scheme for the characters.
+    #[arg(long, value_enum, default_value_t, value_name("FORMAT"))]
+    color_scheme: ColorScheme,
 
     /// Whether to display the position panel on the left.
     #[arg(short('P'), long)]
@@ -429,6 +433,8 @@ fn run() -> Result<()> {
 
     let character_table = opt.character_table;
 
+    let color_scheme = opt.color_scheme;
+
     let mut stdout = BufWriter::new(io::stdout().lock());
 
     let mut printer = PrinterBuilder::new(&mut stdout)
@@ -442,6 +448,7 @@ fn run() -> Result<()> {
         .with_base(base)
         .endianness(endianness)
         .character_table(character_table)
+        .color_scheme(color_scheme)
         .build();
     printer.display_offset(skip_offset + display_offset);
     printer.print_all(&mut reader).map_err(|e| anyhow!(e))?;


### PR DESCRIPTION
When looking at hexdumps, I frequently find myself wishing for easier ways to distinguish between the different bytes that are just specified as `.` in a normal hexdump. I previously experimented with using the Unicode Braille characters for that. When I tried hexyl, I was immediately captured by the idea to add color and thought that color gradients would also add ways to distinguish between different bytes. I thought an image would say more than a thousand words, so I just went ahead and implemented this instead of opening an issue first. I hope this is fine for you.

Without further ado, here is what all bytes would look like with the `--character-table braille --color-scheme gradient` options after this PR is merged:

![all bytes hexdump](https://github.com/user-attachments/assets/1c70837a-79a7-4f4f-adc7-cd9d6c1324ff)


I made several design decisions when implementing this:
1. Setting the colors and the character set are two separate command line options. (Though they go well together, so I will not distinguish specifically between them here. Which option does what is hopefully obvious.)
2.  While different bytes should have different colors, there should still be different classes of bytes, so there are several gradients used.
3. The colors should roughly get "hotter" as the byte values increase.
4. `0x7f` should not be in the same class as the other ASCII-non-printable characters as it has a very different numerical value. Picking this color was difficult, since it had to somehow fit into the general region but still be different enough so as not to be easily confusable.
5. ` ` likely makes more sense in the category of printable ASCII than non-printable ASCII, since it's very likely to be frequently contained in normal text.
6. `0x00`, `\t`, `\n` and `\r` are not really printable charaters, but still important enough to have their own symbols.
7. All other non-printable character are represented using Braille characters corresponding to their bits.

Here are some further examples to hopefully showcase how this can help pattern recognition:

UTF8:
![UTF8 hexdump](https://github.com/user-attachments/assets/5da03f5b-27f0-4819-9396-1ec3c43dd2e3)


UTF16LE with BOM:
![UTF16LE with BOM hexdump](https://github.com/user-attachments/assets/641a563e-720b-40e2-9eac-3784ebd24dcd)


Randomness:
![randomness hexdump](https://github.com/user-attachments/assets/803ef8b6-26d2-45ca-af65-1b854231d0c5)


$MFT entry:
![$MFT entry hexdump](https://github.com/user-attachments/assets/72f35ebf-f3fb-4a48-abae-83b7ab561c50)


hexyl binary (start):
![hexyl binary hexdump](https://github.com/user-attachments/assets/b03b3d61-ff3d-4129-8cab-1ccc9ebaf745)



Unresolved question: How should this interact with the `--print-color-table` option? Currently this option ignores the color scheme. One option would be to show a smaller variant of the gradients with just 3-4 colors there.

Let me if you think anything should be adjusted.

EDIT: Added different character for tabs and changed 0x7f color.