### PR TITLE
Add a CharacterTable format that uses Unicode Control Pictures for whitespace and non-printable ASCII characters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-# unreleased 
+# unreleased
 
 - Fix memory allocation bug when terminal width is less than 10, see #244 (@selfup)
+- Add `--character-table control-pictures` to use [Unicode Control Pictures](https://en.wikipedia.org/wiki/Control_Pictures), e.g. '␀', '␊', '␠', for printing whitespace and non-printable ASCII characters, see #250 (@PaulJuliusMartinez)
 
 ## Features
 


### PR DESCRIPTION
The [Unicode Control Pictures](https://en.wikipedia.org/wiki/Control_Pictures) are intended to be used as graphical representations of ASCII control characters (`0x00` to `0x1f`, and `0x7f`), and space (`0x20`).

This pull request adds `--character-table control-pictures` to use these characters in the character table.

Unfortunately, font support for these is iffy, and some of the three-letter ones (`NUL`, `DEL`) appear as wide characters in terminals, so I'm not sure it would make sense for this to be the default. They are also quite small and can be difficult to read at small font sizes.

I also added tests the dump each character table as part of verifying a debug assertion that I added.

(Apologies for not opening an issue first; implementing it seemed simpler. I'm open to any and all changes.)

<img width="1022" height="849" alt="Screenshot 2025-07-20 at 9 55 12 AM" src="https://github.com/user-attachments/assets/328155ac-edfb-482d-96ec-e193e7d92360" />