### PR TITLE
Add shell completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # unreleased 
 
 - Fix memory allocation bug when terminal width is less than 10, see #244 (@selfup)
+- Add command line argument to generate shell completion, see #155 (@friedz)
 
 ## Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,6 +129,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5abde44486daf70c5be8b8f8f1b66c49f86236edf6fa2abadb4d961c4c6229a"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +231,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "clap_complete",
  "const_format",
  "libc",
  "owo-colors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ owo-colors = "4"
 supports-color = "3"
 thiserror = "1.0"
 terminal_size = "0.4"
+clap_complete = "4"
 
 [dependencies.clap]
 version = "4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,8 @@ use std::num::{NonZeroI64, NonZeroU64};
 use std::path::PathBuf;
 
 use clap::builder::ArgPredicate;
-use clap::{ArgAction, Parser, ValueEnum};
+use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
+use clap_complete::aot::{generate, Shell};
 
 use anyhow::{anyhow, bail, Context, Result};
 
@@ -192,6 +193,13 @@ struct Opt {
     /// Print a table showing how different types of bytes are colored.
     #[arg(long)]
     print_color_table: bool,
+
+    /// Generate a shell completion and print it to stdout.
+    #[arg(
+        long,
+        value_name("SHELL"),
+    )]
+    shell_completion: Option<Shell>,
 }
 
 #[derive(Clone, Debug, Default, ValueEnum)]
@@ -246,6 +254,13 @@ fn run() -> Result<()> {
 
     if opt.print_color_table {
         return print_color_table().map_err(|e| anyhow!(e));
+    }
+
+    if let Some(sh) = opt.shell_completion {
+        let mut cmd = Opt::command();
+        let name = cmd.get_name().to_string();
+        generate(sh, &mut cmd, name, &mut io::stdout());
+        return Ok(());
     }
 
     let stdin = io::stdin();

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,10 +195,7 @@ struct Opt {
     print_color_table: bool,
 
     /// Generate a shell completion and print it to stdout.
-    #[arg(
-        long,
-        value_name("SHELL"),
-    )]
+    #[arg(long, value_name("SHELL"))]
     shell_completion: Option<Shell>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,9 +194,9 @@ struct Opt {
     #[arg(long)]
     print_color_table: bool,
 
-    /// Generate a shell completion and print it to stdout.
+    /// Show shell completion for a certain shell
     #[arg(long, value_name("SHELL"))]
-    shell_completion: Option<Shell>,
+    completion: Option<Shell>,
 }
 
 #[derive(Clone, Debug, Default, ValueEnum)]
@@ -253,7 +253,7 @@ fn run() -> Result<()> {
         return print_color_table().map_err(|e| anyhow!(e));
     }
 
-    if let Some(sh) = opt.shell_completion {
+    if let Some(sh) = opt.completion {
         let mut cmd = Opt::command();
         let name = cmd.get_name().to_string();
         generate(sh, &mut cmd, name, &mut io::stdout());


### PR DESCRIPTION
I added a command line argument to run clap_generate for all the shells it supports out of the box. See #155 and fish being one of the shells probably also #223 

I tried to have the generation be run at compile time but while it doesn't look like it's impossible it seems impractical. Perhaps a similar result can be archived by running `hexyl --shell-completion <SHELL> > <completion file>` in the CI for all supported shells.