### PR TITLE
Add colors to --help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `--color-scheme` option, see #247 (@aticu)
 - Add `braille` character table, see #247 (@aticu)
 - Add command line argument to generate shell completion, see #155 (@friedz)
+- Add colors to `--help`/`-h`, see #253 (@starsep)
 
 ## Bugfixes
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,9 @@ use std::io::{self, prelude::*, BufWriter, SeekFrom};
 use std::num::{NonZeroI64, NonZeroU64};
 use std::path::PathBuf;
 
+use clap::builder::styling::{AnsiColor, Effects};
 use clap::builder::ArgPredicate;
+use clap::builder::Styles;
 use clap::{ArgAction, CommandFactory, Parser, ValueEnum};
 use clap_complete::aot::{generate, Shell};
 
@@ -54,8 +56,14 @@ Since the terminal width may not be an evenly divisible by the width per hex dat
                                         the right.
 Cannot be used with other width-setting options.";
 
+const STYLES: Styles = Styles::styled()
+    .header(AnsiColor::Green.on_default().effects(Effects::BOLD))
+    .usage(AnsiColor::Green.on_default().effects(Effects::BOLD))
+    .literal(AnsiColor::Cyan.on_default().effects(Effects::BOLD))
+    .placeholder(AnsiColor::Cyan.on_default());
+
 #[derive(Debug, Parser)]
-#[command(version, about, max_term_width(90))]
+#[command(version, about, max_term_width(90), styles = STYLES)]
 struct Opt {
     /// The file to display. If no FILE argument is given, read from STDIN.
     #[arg(value_name("FILE"))]


### PR DESCRIPTION
User can disable colors via `NO_COLOR=1` environment variable if needed

Output of `hexyl -h`:
| before | after | `NO_COLOR=1` |
| - | - | - |
| <img width="874" height="1516" alt="hexyl-before" src="https://github.com/user-attachments/assets/bc68c279-b02c-44a8-8251-2d458e720d8f" /> | <img width="874" height="1516" alt="hexyl-colors" src="https://github.com/user-attachments/assets/76fb7b69-b8e3-4b85-bd88-093d19e408f6" /> | <img width="874" height="1516" alt="hexyl-no-color" src="https://github.com/user-attachments/assets/c931f543-efba-408a-8811-46f1338d7947" /> |