### PR TITLE
feat: handle standard input "-"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -469,6 +469,7 @@ fn run() -> Result<()> {
         // include mode on
         true => {
             if let Some(include_file) = opt.file {
+                // input from a file
                 if include_file.as_os_str() == "-" {
                     IncludeMode::File("stdin".to_string())
                 } else {


### PR DESCRIPTION
feat: handle standard input "-" and remove a `unwrap()`

```
$ echo 1 | cargo run -- -
┌────────┬─────────────────────────┬─────────────────────────┬────────┬────────┐
│00000000│ 31 0a                   ┊                         │1_      ┊        │
└────────┴─────────────────────────┴─────────────────────────┴────────┴────────┘

$ echo -n 1 | cargo run -- -
┌────────┬─────────────────────────┬─────────────────────────┬────────┬────────┐
│00000000│ 31                      ┊                         │1       ┊        │
└────────┴─────────────────────────┴─────────────────────────┴────────┴────────┘

$ echo 1 | cargo run -- -i -
unsigned char stdin[] = {
  0x31, 0x0a
};
unsigned int stdin_len = 2;
```