### PR TITLE
ci: add native Windows ARM64 release

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -81,6 +81,7 @@ jobs:
           # Was causing CI failures unrelated to app logic
           # - { target: x86_64-pc-windows-gnu       , os: windows-2019                  }
           - { target: x86_64-pc-windows-msvc      , os: windows-2025                  }
+          - { target: aarch64-pc-windows-msvc     , os: windows-11-arm                }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-24.04, use-cross: true }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-24.04, use-cross: true }
     env:


### PR DESCRIPTION
## Summary

Add aarch64-pc-windows-msvc to the existing release matrix using the native windows-11-arm runner.

## Validation

The complete workflow passed in my fork, including native Windows ARM64 build, tests, packaging, and artifact upload:
https://github.com/meop/hexyl/actions/runs/31940648131

## Disclosure

This change was prepared with assistance from OpenAI Codex. I reviewed the resulting diff and validated it through the linked GitHub Actions run.