### PR TITLE
ci: add Linux ARM64 musl release target

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -71,6 +71,7 @@ jobs:
       matrix:
         job:
           - { target: aarch64-unknown-linux-gnu   , os: ubuntu-24.04, use-cross: true }
+          - { target: aarch64-unknown-linux-musl  , os: ubuntu-24.04, use-cross: true }
           - { target: arm-unknown-linux-gnueabihf , os: ubuntu-24.04, use-cross: true }
           - { target: arm-unknown-linux-musleabihf, os: ubuntu-24.04, use-cross: true }
           - { target: i686-pc-windows-msvc        , os: windows-2025                  }


### PR DESCRIPTION
## Summary

Add `aarch64-unknown-linux-musl` to the existing cross-compilation matrix, alongside the already supported Linux ARM64 GNU target.

## Validation

The full CI run, including the new target, passed: [CICD](https://github.com/meop/hexyl/actions/runs/33244053520). The uploaded ARM64-musl binary was inspected after the run and is statically linked.
